### PR TITLE
Amiplus-patch for tarrifs T1, T2, T3, T4

### DIFF
--- a/components/wmbus/__init__.py
+++ b/components/wmbus/__init__.py
@@ -127,5 +127,5 @@ async def to_code(config):
     cg.add_library(
         None,
         None,
-        "https://github.com/SzczepanLeon/wmbus-drivers#1.3.11",
+        "https://github.com/SzczepanLeon/wmbus-drivers#1.3.12",
     )

--- a/components/wmbus/__init__.py
+++ b/components/wmbus/__init__.py
@@ -127,5 +127,5 @@ async def to_code(config):
     cg.add_library(
         None,
         None,
-        "https://github.com/SzczepanLeon/wmbus-drivers#1.3.11",
+        "https://github.com/augustynski-lukasz/wmbus-drivers#amiplus-patch",
     )

--- a/components/wmbus/__init__.py
+++ b/components/wmbus/__init__.py
@@ -127,5 +127,5 @@ async def to_code(config):
     cg.add_library(
         None,
         None,
-        "https://github.com/augustynski-lukasz/wmbus-drivers#amiplus-patch",
+        "https://github.com/SzczepanLeon/wmbus-drivers#1.3.11",
     )

--- a/components/wmbus/sensor/__init__.py
+++ b/components/wmbus/sensor/__init__.py
@@ -135,6 +135,27 @@ CONFIG_SCHEMA = cv.Schema(
             state_class=STATE_CLASS_TOTAL_INCREASING,
             icon="mdi:transmission-tower-export",
         ),
+        cv.Optional("total_energy_consumption_t1_kwh"): sensor.sensor_schema(
+            accuracy_decimals=3,
+            unit_of_measurement=UNIT_KILOWATT_HOURS,
+            device_class=DEVICE_CLASS_ENERGY,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
+            icon="mdi:transmission-tower-export",
+        ),
+        cv.Optional("total_energy_consumption_t2_kwh"): sensor.sensor_schema(
+            accuracy_decimals=3,
+            unit_of_measurement=UNIT_KILOWATT_HOURS,
+            device_class=DEVICE_CLASS_ENERGY,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
+            icon="mdi:transmission-tower-export",
+        ),
+        cv.Optional("total_energy_consumption_t3_kwh"): sensor.sensor_schema(
+            accuracy_decimals=3,
+            unit_of_measurement=UNIT_KILOWATT_HOURS,
+            device_class=DEVICE_CLASS_ENERGY,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
+            icon="mdi:transmission-tower-export",
+        ),                        
         cv.Optional("current_power_consumption_kw"): sensor.sensor_schema(
             accuracy_decimals=3,
             unit_of_measurement=UNIT_KILOWATT,

--- a/components/wmbus/sensor/__init__.py
+++ b/components/wmbus/sensor/__init__.py
@@ -155,6 +155,13 @@ CONFIG_SCHEMA = cv.Schema(
             device_class=DEVICE_CLASS_ENERGY,
             state_class=STATE_CLASS_TOTAL_INCREASING,
             icon="mdi:transmission-tower-export",
+        ), 
+        cv.Optional("total_energy_consumption_t4_kwh"): sensor.sensor_schema(
+            accuracy_decimals=3,
+            unit_of_measurement=UNIT_KILOWATT_HOURS,
+            device_class=DEVICE_CLASS_ENERGY,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
+            icon="mdi:transmission-tower-export",
         ),                        
         cv.Optional("current_power_consumption_kw"): sensor.sensor_schema(
             accuracy_decimals=3,
@@ -164,6 +171,34 @@ CONFIG_SCHEMA = cv.Schema(
             icon="mdi:transmission-tower-export",
         ),
         cv.Optional("total_energy_production_kwh"): sensor.sensor_schema(
+            accuracy_decimals=3,
+            unit_of_measurement=UNIT_KILOWATT_HOURS,
+            device_class=DEVICE_CLASS_ENERGY,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
+            icon="mdi:transmission-tower-import",
+        ),
+        cv.Optional("total_energy_production_t1_kwh"): sensor.sensor_schema(
+            accuracy_decimals=3,
+            unit_of_measurement=UNIT_KILOWATT_HOURS,
+            device_class=DEVICE_CLASS_ENERGY,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
+            icon="mdi:transmission-tower-import",
+        ),
+        cv.Optional("total_energy_production_t2_kwh"): sensor.sensor_schema(
+            accuracy_decimals=3,
+            unit_of_measurement=UNIT_KILOWATT_HOURS,
+            device_class=DEVICE_CLASS_ENERGY,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
+            icon="mdi:transmission-tower-import",
+        ),
+        cv.Optional("total_energy_production_t3_kwh"): sensor.sensor_schema(
+            accuracy_decimals=3,
+            unit_of_measurement=UNIT_KILOWATT_HOURS,
+            device_class=DEVICE_CLASS_ENERGY,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
+            icon="mdi:transmission-tower-import",
+        ),
+        cv.Optional("total_energy_production_t4_kwh"): sensor.sensor_schema(
             accuracy_decimals=3,
             unit_of_measurement=UNIT_KILOWATT_HOURS,
             device_class=DEVICE_CLASS_ENERGY,

--- a/components/wmbus/version.h
+++ b/components/wmbus/version.h
@@ -1,3 +1,3 @@
 #ifndef MY_VERSION
-#define MY_VERSION "3.2.1"
+#define MY_VERSION "3.2.2"
 #endif


### PR DESCRIPTION
Added total_energy_production_tX_kwh and total_energy_consumption_tX_kwh for tarrifs T1, T2, T3, T3, according to documentation https://amiplus.tauron-dystrybucja.pl/-/media/offer-documents/amiplus/amiplus-modu-wireless-m-bus.ashx