### PR TITLE
Extend support for Kamstrup Multical21

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ Supported sensors (sensor_type) for meters:
 - `multical21`
   - total_water_m3
   - target_water_m3
+  - flow_temperature_c (depends on meter configuration)
+  - external_temperature_c (depends on meter configuration)
 - `qheat`
   - total_energy_consumption_kwh
 - `qwater`

--- a/components/wmbus/__init__.py
+++ b/components/wmbus/__init__.py
@@ -127,5 +127,5 @@ async def to_code(config):
     cg.add_library(
         None,
         None,
-        "https://github.com/cenobitedk/wmbus-drivers#dev/multical21",
+        "https://github.com/cenobitedk/wmbus-drivers#multical21",
     )

--- a/components/wmbus/__init__.py
+++ b/components/wmbus/__init__.py
@@ -127,5 +127,5 @@ async def to_code(config):
     cg.add_library(
         None,
         None,
-        "https://github.com/cenobitedk/wmbus-drivers#multical21",
+        "https://github.com/SzczepanLeon/wmbus-drivers#1.3.13",
     )

--- a/components/wmbus/__init__.py
+++ b/components/wmbus/__init__.py
@@ -127,5 +127,5 @@ async def to_code(config):
     cg.add_library(
         None,
         None,
-        "https://github.com/SzczepanLeon/wmbus-drivers#1.3.12",
+        "https://github.com/cenobitedk/wmbus-drivers#dev/multical21",
     )

--- a/components/wmbus/sensor/__init__.py
+++ b/components/wmbus/sensor/__init__.py
@@ -310,6 +310,13 @@ CONFIG_SCHEMA = cv.Schema(
             state_class=STATE_CLASS_MEASUREMENT,
             icon="mdi:coolant-temperature",
         ),
+        cv.Optional("external_temperature_c"): sensor.sensor_schema(
+            accuracy_decimals=0,
+            unit_of_measurement=UNIT_CELSIUS,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+            icon="mdi:thermometer",
+        ),
         cv.Optional("voltage_at_phase_1_v"): sensor.sensor_schema(
             accuracy_decimals=0,
             unit_of_measurement=UNIT_VOLT,

--- a/components/wmbus/version.h
+++ b/components/wmbus/version.h
@@ -1,3 +1,3 @@
 #ifndef MY_VERSION
-#define MY_VERSION "3.2.2"
+#define MY_VERSION "3.2.3"
 #endif


### PR DESCRIPTION
This PR in combination with [this PR](https://github.com/SzczepanLeon/wmbus-drivers/pull/11) extends the support for type `multical21`:

- Support compact frames
- Support `flow_temperature_c`
- Support `external_temperature_c`

Compact frames are sent every 16 second and long frames every 96 seconds, making it quite desirable to support compact frames.

Support for info codes (OK, DRY, LEAK, BURST) is not added as it would require a text sensor. However, an alternative solution would be to support the raw code (`0x00`, `0x01` etc.) and use a template text sensor to convert it to a string value.

Here's a config example with all the values supported:

```
sensor:
  - platform: wmbus
    meter_id: ...
    type: multical21
    key: "..."
    mode: C1
    lqi:
      name: "LQI"
    rssi:
      name: "RSSI"
    total_water_m3:
      name: "Total Water m3"
    target_water_m3:
      name: "Target Water m3"
    flow_temperature_c:
      name: "Flow Temperature °C"
    external_temperature_c:
      name: "Ambient Temperature °C"
```

Note: lib url should be updated once the related PR for `wmbus-drivers` has been added.