### PR TITLE
Add option to send raw telegrams over mqtt.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,178 @@
+# Created by https://www.toptal.com/developers/gitignore/api/python
+# Edit at https://www.toptal.com/developers/gitignore?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
+# End of https://www.toptal.com/developers/gitignore/api/python
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -254,8 +254,14 @@ In wmbus platform:
   - **password** (**Required**): password.
   - **port** (*Optional*): Port number. Defaults to ``1883``.
   - **retain** (*Optional*): If the published message should have a retain flag on or not. Defaults to ``False``.
+- **mqtt_raw** (*Optional*): Send raw telegrams over mqtt, even for non configured sensors. Defaults to ``False``.
+- **mqtt_raw_parsed** (*Optional*): Wheteher raw frames should be send after parsing header. If so, their address will be included in topic, and json data. If `True`, then address will be appended to topic: `(...)/raw/<address>`. Otherwise `(...)/raw`. Defaults to ``True``. 
+- **mqtt_raw_prefix** (*Optional*): Topic prefix for raw frames: `<mqtt_raw_prefix>(/)<app_name>/wmbus/raw[/<address>]`. Defaults to ``""``
+- **mqtt_raw_format** (*Optional*): Format of raw frames to send. `RTLWMBUS` or `JSON`. Defaults to `JSON`. 
 
 > **_NOTE:_**  MQTT can be defined in wmbus component or in [ESPHome level](https://esphome.io/components/mqtt.html).
+> The later will reuse connection managed by ESPHome, while former whill open and close connection on each packet. 
+> Bbroker defined on wmbus component level will take priority (event if both are defined).
 
 
 sensor:

--- a/components/wmbus/__init__.py
+++ b/components/wmbus/__init__.py
@@ -42,6 +42,8 @@ CONF_INFO_COMP_ID = "info_comp_id"
 CONF_WMBUS_MQTT_ID = "wmbus_mqtt_id"
 CONF_WMBUS_MQTT_RAW = "mqtt_raw"
 CONF_WMBUS_MQTT_RAW_PREFIX = "mqtt_raw_prefix"
+CONF_WMBUS_MQTT_RAW_PARSED = "mqtt_raw_parsed"
+CONF_WMBUS_MQTT_RAW_FORMAT = "mqtt_raw_format"
 CONF_CLIENTS = 'clients'
 CONF_ETH_REF = "wmbus_eth_id"
 CONF_WIFI_REF = "wmbus_wifi_id"
@@ -56,6 +58,7 @@ WMBusComponent = wmbus_ns.class_('WMBusComponent', cg.Component)
 InfoComponent = wmbus_ns.class_('InfoComponent', cg.Component)
 Client = wmbus_ns.struct('Client')
 Format = wmbus_ns.enum("Format")
+RawFormat = wmbus_ns.enum("RawFormat")
 Transport = wmbus_ns.enum("Transport")
 MqttClient = wmbus_ns.struct('MqttClient')
 
@@ -64,6 +67,12 @@ FORMAT = {
     "RTLWMBUS": Format.FORMAT_RTLWMBUS,
 }
 validate_format = cv.enum(FORMAT, upper=True)
+
+RAW_FORMAT = {
+    "JSON": RawFormat.RAW_FORMAT_JSON,
+    "RTLWMBUS": RawFormat.RAW_FORMAT_RTLWMBUS,
+}
+validate_raw_format = cv.enum(RAW_FORMAT, upper=True)
 
 TRANSPORT = {
     "TCP": Transport.TRANSPORT_TCP,
@@ -112,6 +121,8 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Optional(CONF_MQTT):                            cv.ensure_schema(WMBUS_MQTT_SCHEMA),
     cv.Optional(CONF_WMBUS_MQTT_RAW, default=False): cv.boolean,
     cv.Optional(CONF_WMBUS_MQTT_RAW_PREFIX, default=""): cv.string,
+    cv.Optional(CONF_WMBUS_MQTT_RAW_FORMAT, default="JSON"): cv.templatable(validate_raw_format),
+    cv.Optional(CONF_WMBUS_MQTT_RAW_PARSED, default=True): cv.boolean,
 })
 
 def safe_ip(ip):
@@ -167,6 +178,8 @@ async def to_code(config):
 
     cg.add(var.set_mqtt_raw(config[CONF_WMBUS_MQTT_RAW]))
     cg.add(var.set_mqtt_raw_prefix(config[CONF_WMBUS_MQTT_RAW_PREFIX]))
+    cg.add(var.set_mqtt_raw_format(config[CONF_WMBUS_MQTT_RAW_FORMAT]))
+    cg.add(var.set_mqtt_raw_parsed(config[CONF_WMBUS_MQTT_RAW_PARSED]))
 
     cg.add(var.set_log_all(config[CONF_LOG_ALL]))
 

--- a/components/wmbus/__init__.py
+++ b/components/wmbus/__init__.py
@@ -40,6 +40,8 @@ CONF_ALL_DRIVERS = "all_drivers"
 CONF_SYNC_MODE = "sync_mode"
 CONF_INFO_COMP_ID = "info_comp_id"
 CONF_WMBUS_MQTT_ID = "wmbus_mqtt_id"
+CONF_WMBUS_MQTT_RAW = "mqtt_raw"
+CONF_WMBUS_MQTT_RAW_PREFIX = "mqtt_raw_prefix"
 CONF_CLIENTS = 'clients'
 CONF_ETH_REF = "wmbus_eth_id"
 CONF_WIFI_REF = "wmbus_wifi_id"
@@ -108,6 +110,8 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Optional(CONF_FREQUENCY,      default=868.950): cv.float_range(min=300, max=928),
     cv.Optional(CONF_SYNC_MODE,      default=False):   cv.boolean,
     cv.Optional(CONF_MQTT):                            cv.ensure_schema(WMBUS_MQTT_SCHEMA),
+    cv.Optional(CONF_WMBUS_MQTT_RAW, default=False): cv.boolean,
+    cv.Optional(CONF_WMBUS_MQTT_RAW_PREFIX, default=""): cv.string,
 })
 
 def safe_ip(ip):
@@ -160,6 +164,9 @@ async def to_code(config):
                             safe_ip(conf[CONF_BROKER]),
                             conf[CONF_PORT],
                             conf[CONF_RETAIN]))
+
+    cg.add(var.set_mqtt_raw(config[CONF_WMBUS_MQTT_RAW]))
+    cg.add(var.set_mqtt_raw_prefix(config[CONF_WMBUS_MQTT_RAW_PREFIX]))
 
     cg.add(var.set_log_all(config[CONF_LOG_ALL]))
 

--- a/components/wmbus/version.h
+++ b/components/wmbus/version.h
@@ -1,4 +1,4 @@
 #ifndef MY_VERSION
-#define MY_VERSION "4.1.5"
+#define MY_VERSION "4.2.0"
 #define WMBUSMETERS_VERSION "1.17.1-b8f4a945"
 #endif

--- a/components/wmbus/wmbus.cpp
+++ b/components/wmbus/wmbus.cpp
@@ -68,9 +68,6 @@ namespace wmbus {
         ESP_LOGE(TAG, "Address is empty! T: %s", telegram.c_str());
       }
       else {
-# if defined(USE_WMBUS_MQTT) || defined(USE_MQTT)
-        send_mqtt_raw(t, mbus_data);
-#endif
         uint32_t meter_id = (uint32_t)strtoul(t.addresses[0].id.c_str(), nullptr, 16);
         bool meter_in_config = (this->wmbus_listeners_.count(meter_id) == 1) ? true : false;
         
@@ -202,6 +199,11 @@ namespace wmbus {
           }
         }
       }
+# if defined(USE_WMBUS_MQTT) || defined(USE_MQTT)
+      if (this->mqtt_raw) {
+        send_mqtt_raw(t, mbus_data);
+      }
+#endif
     }
   }
 
@@ -236,39 +238,68 @@ namespace wmbus {
 
 #if defined(USE_WMBUS_MQTT) || defined(USE_MQTT)
   void WMBusComponent::send_mqtt_raw(Telegram &t, WMbusFrame &mbus_data) {
-    if (this->mqtt_raw) {
-      std::string json;
-      json += "{";
-      json += "\"id\": \"" + t.addresses[0].id + "\", ";
-      json += "\"mode\": \"" + std::string(1, mbus_data.mode) + "\", ";
-      json += "\"rssi\": " + std::to_string(mbus_data.rssi) + ", ";
-      json += "\"frame\": \"";
-      for (int i = 0; i < mbus_data.frame.size(); i++) {
-        char hex_byte[3]; // 2 characters for hex + 1 for null terminator
-        std::snprintf(hex_byte, sizeof(hex_byte), "%02X", mbus_data.frame[i]);
-        json += hex_byte;
-      }
-      json += "\"}";
-
-      std::string name = App.get_friendly_name().empty() ? App.get_name() : App.get_friendly_name();
-      std::string mqtt_topic = str_sanitize(name) + "/wmbus/raw";
-      if (this->mqtt_raw_prefix.size() > 0) {
-        mqtt_topic = this->mqtt_raw_prefix + "/" + mqtt_topic;
-      }
-#ifdef USE_WMBUS_MQTT
-      if (this->mqtt_client_.connect("", this->mqtt_->name.c_str(), this->mqtt_->password.c_str())) {
-        this->mqtt_client_.publish(mqtt_topic.c_str(), json.c_str(), this->mqtt_->retained);
-        ESP_LOGV(TAG, "Publishing raw(topic='%s' payload='%s' retain=%d)", mqtt_topic.c_str(), json.c_str(), this->mqtt_->retained);
-        this->mqtt_client_.disconnect();
-      }
-      else {
-        ESP_LOGV(TAG, "Publish failed raw for topic='%s' (len=%u).", mqtt_topic.c_str(), json.length());
-      }
-#elif defined(USE_MQTT)
-      this->mqtt_client_->publish(mqtt_topic, json);
-      // this->mqtt_client_->publish("meteringinternal/v1/wmbus/raw", "foo");
-#endif
+    bool is_parsed = !t.addresses.empty();
+    if (!is_parsed && !this->mqtt_raw_parsed) {
+      return;
     }
+
+    std::string payload;
+    std::string name = App.get_friendly_name().empty() ? App.get_name() : App.get_friendly_name();
+    std::string mqtt_topic = str_sanitize(name) + "/wmbus/raw";
+
+    if (this->mqtt_raw_prefix.size() > 0) {
+      mqtt_topic = this->mqtt_raw_prefix + "/" + mqtt_topic;
+    }
+
+    if (is_parsed && this->mqtt_raw_parsed) {
+      mqtt_topic += "/" + t.addresses[0].id;
+    }
+
+    switch(this->mqtt_raw_format) {
+      case RAW_FORMAT_RTLWMBUS: 
+        char telegram_time[24];
+        strftime(telegram_time, sizeof(telegram_time), "%Y-%m-%d %H:%M:%S.00Z", gmtime(&(this->frame_timestamp_)));
+
+        // Start building the payload
+        payload += std::string(1, mbus_data.mode) + "1;1;1;" + telegram_time + ";" + std::to_string(mbus_data.rssi) + ";;;0x";
+
+        // Add the formatted hex frame
+        for (int i = 0; i < mbus_data.frame.size(); i++) {
+          char hex_byte[3]; // 2 characters for hex + 1 for null terminator
+          std::snprintf(hex_byte, sizeof(hex_byte), "%02X", mbus_data.frame[i]);
+          payload += hex_byte;
+        }
+
+        break;
+      
+      default:
+        payload += "{";
+        if (is_parsed) {
+          payload += "\"address\": \"" + t.addresses[0].id + "\", ";
+        }
+        payload += "\"mode\": \"" + std::string(1, mbus_data.mode) + "\", ";
+        payload += "\"rssi\": " + std::to_string(mbus_data.rssi) + ", ";
+        payload += "\"frame\": \"";
+        for (int i = 0; i < mbus_data.frame.size(); i++) {
+          char hex_byte[3]; // 2 characters for hex + 1 for null terminator
+          std::snprintf(hex_byte, sizeof(hex_byte), "%02X", mbus_data.frame[i]);
+          payload += hex_byte;
+        }
+        payload += "\"}";
+  }
+
+#ifdef USE_WMBUS_MQTT
+    if (this->mqtt_client_.connect("", this->mqtt_->name.c_str(), this->mqtt_->password.c_str())) {
+      this->mqtt_client_.publish(mqtt_topic.c_str(), payload.c_str(), this->mqtt_->retained);
+      ESP_LOGV(TAG, "Publishing raw(topic='%s' payload='%s' retain=%d)", mqtt_topic.c_str(), payload.c_str(), this->mqtt_->retained);
+      this->mqtt_client_.disconnect();
+    }
+    else {
+      ESP_LOGV(TAG, "Publish failed raw for topic='%s' (len=%u).", mqtt_topic.c_str(), payload.length());
+    }
+#elif defined(USE_MQTT)
+    this->mqtt_client_->publish(mqtt_topic, payload);
+#endif
   }
 #endif
   

--- a/components/wmbus/wmbus.h
+++ b/components/wmbus/wmbus.h
@@ -148,6 +148,8 @@ namespace wmbus {
 #elif defined(USE_MQTT)
       void set_mqtt(mqtt::MQTTClientComponent *mqtt_client) { this->mqtt_client_ = mqtt_client; }
 #endif
+      void set_mqtt_raw(bool send_raw) { this->mqtt_raw = send_raw; }
+      void set_mqtt_raw_prefix(std::string prefix) { this->mqtt_raw_prefix = prefix; }
       void set_log_all(bool log_all) { this->log_all_ = log_all; }
       void add_client(const std::string name,
                       const network::IPAddress ip,
@@ -163,6 +165,7 @@ namespace wmbus {
       const LogString *format_to_string(Format format);
       const LogString *transport_to_string(Transport transport);
       void send_to_clients(WMbusFrame &mbus_data);
+      void send_mqtt_raw(Telegram &t, WMbusFrame &mbus_data);
       void led_blink();
       void led_handler();
       HighFrequencyLoopRequester high_freq_;
@@ -191,6 +194,10 @@ namespace wmbus {
 #elif defined(USE_MQTT)
       mqtt::MQTTClientComponent *mqtt_client_{nullptr};
 #endif
+// #if defined(USE_WMBUS_MQTT) || defined(USE_MQTT)
+      bool mqtt_raw{false};
+      std::string mqtt_raw_prefix{""};
+// #endif
       time_t frame_timestamp_;
   };
 

--- a/components/wmbus/wmbus.h
+++ b/components/wmbus/wmbus.h
@@ -41,6 +41,11 @@ namespace wmbus {
     FORMAT_RTLWMBUS = 1,
   };
 
+  enum RawFormat : uint8_t {
+    RAW_FORMAT_JSON     = 0,
+    RAW_FORMAT_RTLWMBUS = 1,
+  };
+
   enum Transport : uint8_t {
     TRANSPORT_TCP = 0,
     TRANSPORT_UDP = 1,
@@ -150,6 +155,8 @@ namespace wmbus {
 #endif
       void set_mqtt_raw(bool send_raw) { this->mqtt_raw = send_raw; }
       void set_mqtt_raw_prefix(std::string prefix) { this->mqtt_raw_prefix = prefix; }
+      void set_mqtt_raw_parsed(bool parsed) { this->mqtt_raw_parsed = parsed; }
+      void set_mqtt_raw_format(RawFormat format) { this->mqtt_raw_format = format; }
       void set_log_all(bool log_all) { this->log_all_ = log_all; }
       void add_client(const std::string name,
                       const network::IPAddress ip,
@@ -194,10 +201,10 @@ namespace wmbus {
 #elif defined(USE_MQTT)
       mqtt::MQTTClientComponent *mqtt_client_{nullptr};
 #endif
-// #if defined(USE_WMBUS_MQTT) || defined(USE_MQTT)
       bool mqtt_raw{false};
+      bool mqtt_raw_parsed{true};
+      bool mqtt_raw_format{RAW_FORMAT_JSON};
       std::string mqtt_raw_prefix{""};
-// #endif
       time_t frame_timestamp_;
   };
 

--- a/docs/wmbus.md
+++ b/docs/wmbus.md
@@ -32,6 +32,18 @@ wmbus:
   - **port**: port where telegrams will be sent
   - **format**: telegram format should be set to ``RTLWMBUS``
 
+MQTT example:
+```yaml
+mqtt:
+  broker: broker.local
+# (...)
+wmbus:
+  mqtt_raw: true
+  mqtt_raw_prefix: someprefix
+  mqtt_raw_format: RTLWMBUS
+  mqtt_raw_parsed: true
+  # mqtt broker can be also specified here
+```
 
 ## 2. `wmbus` addon configuration
 After instalation please go to addon configuration and enable port forwarding by clicking `Show disabled ports`:
@@ -51,6 +63,14 @@ TCP case:
 ```yaml
 device=rtlwmbus:CMD(/usr/bin/nc -lk 9022)
 ```
+
+MQTT case:
+```yaml
+device=rtlwmbus:CMD(mosquitto_sub -h broker.local -t someprefix/+/wmbus/raw/+)
+# or in case of mqtt_raw_parsed: false
+device=rtlwmbus:CMD(mosquitto_sub -h broker.local -t someprefix/+/wmbus/raw)
+```
+
 
 Add meters:
 ```yaml


### PR DESCRIPTION
This PR enables sending raw telegrams over mqtt (instead of raw TCP/UDP sockets) which is also suggested option in [`wmbusmeters` docs](https://github.com/wmbusmeters/wmbusmeters/blob/41dc2d47fda72e78964b9283c99a0c98492360ba/README.md#L902). Using raw sockets is limited to local network (and is not best practice), while mqtt allows for decoding frames anywhere.
 
`mqtt_raw_parsed` with json format aim for decoding telegrams in custom programs (non-wmbusmeters). Knowing address before decoding frame allows for encryption key lookup before calling `wmbusmeters --analyze=<key> <frame>`. 