### PR TITLE
Adjust to latest ESPHome 2025.5.0

### DIFF
--- a/components/wmbus/__init__.py
+++ b/components/wmbus/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins
-from esphome.log import Fore, color
+from esphome.log import AnsiFore, color
 from esphome.components import time
 from esphome.components import mqtt
 from esphome.components import wifi
@@ -135,7 +135,7 @@ async def to_code(config):
     await cg.register_component(var_adv, {})
 
     if (config.get(CONF_MQTT_ID) and config.get(CONF_MQTT)):
-        print(color(Fore.RED, "Only one MQTT can be configured!"))
+        print(color(AnsiFore.RED, "Only one MQTT can be configured!"))
         exit()
 
     var = cg.new_Pvariable(config[CONF_ID])


### PR DESCRIPTION
Due to this change:
https://github.com/esphome/esphome/pull/8708/files

there was an error:
`ERROR Unable to import component wmbus:
Traceback (most recent call last):
  File "/esphome/esphome/loader.py", line 185, in _lookup_module
    module = importlib.import_module(f"esphome.components.{domain}")
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 999, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/data/external_components/5c086c68/components/wmbus/__init__.py", line 4, in <module>
    from esphome.log import Fore, color
ImportError: cannot import name 'Fore' from 'esphome.log' (/esphome/esphome/log.py). Did you mean: 'core'?
Failed config`