### PR TITLE
updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ mqtt:
 
 wmbus_radio:
   radio_type: SX1276
-  cs_pin: GPIO15
-  reset_pin: GPIO18
-  irq_pin: GPIO26   #DIO1
+  cs_pin: GPIO18
+  reset_pin: GPIO14
+  irq_pin: GPIO35
   on_frame:
     - then:
         - repeat:

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ mqtt:
 
 wmbus_radio:
   radio_type: SX1276
-  cs_pin: GPIO18
-  reset_pin: GPIO14
-  irq_pin: GPIO35
+  cs_pin: GPIO15
+  reset_pin: GPIO18
+  irq_pin: GPIO26   #DIO1
   on_frame:
     - then:
         - repeat:
@@ -102,11 +102,11 @@ wmbus_radio:
       then:
         - mqtt.publish:
             topic: wmbus-test/telegram_rtl
-            payload: !lambda return frame.as_rtlwmbus();
+            payload: !lambda return frame->as_rtlwmbus();
     - mark_as_handled: True
       then:
-        - wmbus_radio.send_frame_with_socket:
-            format: hex
+        - socket_transmitter.send:
+            data: !lambda return frame->as_hex();
 
 wmbus_meter:
   - id: electricity_meter


### PR DESCRIPTION
Fixed pointer access: Changed frame.as_hex to frame->as_hex() since frame is a pointer to a Frame object, not the object itself.
Fixed socket transmitter syntax: Replaced wmbus_radio.send_frame_with_socket: with socket_transmitter.send: which is the correct ESPHome action syntax.
Added proper lambda return: Made sure the lambda function properly returns the hex string with return frame->as_hex();