### PR TITLE
add 'flow temperature' field for hydrus watermeter

### DIFF
--- a/components/wmbus/driver_hydrus.cpp
+++ b/components/wmbus/driver_hydrus.cpp
@@ -89,6 +89,16 @@ namespace
             );
 
         addNumericFieldWithExtractor(
+            "flow_temperature_c",
+            "The flow temperature",
+            DEFAULT_PRINT_PROPERTIES,
+            Quantity::Temperature,
+            VifScaling::Auto, DifSignedness::Signed,
+            FieldMatcher::build()
+            .set(MeasurementType::Instantaneous)
+            .set(VIFRange::FlowTemperature));
+
+        addNumericFieldWithExtractor(
             "flow",
             "The current water flow.",
             DEFAULT_PRINT_PROPERTIES,


### PR DESCRIPTION
the flow temperature for Hydrus watermeter was missing. With this change the yaml can have this section.

```yaml
- name: "Temperature"
  field: "flow_temperature_c"
  accuracy_decimals: 3
  unit_of_measurement: "°C"
  device_class: "temperature"
  state_class: "measurement"
```

the result will look like this:
![image](https://github.com/user-attachments/assets/e98422dd-bf72-4876-a543-86412b1dcff3)
