### PR TITLE
Add battery field for Unismart driver

### DIFF
--- a/components/wmbus/driver_unismart.cpp
+++ b/components/wmbus/driver_unismart.cpp
@@ -159,6 +159,16 @@ namespace
             .set(IndexNr(2))
             );
 
+        addNumericFieldWithExtractor(
+            "battery",
+            "Remaining battery life in days.",
+            DEFAULT_PRINT_PROPERTIES,
+            Quantity::Time,
+            VifScaling::None, DifSignedness::Signed,
+            FieldMatcher::build()
+            .set(MeasurementType::Instantaneous)
+            .set(VIFRange::RemainingBattery),
+            Unit::Day);
     }
 }
 


### PR DESCRIPTION
Had been build tested using my fork. 
```
external_components:
  - source: github://AreYouLoco/esphome-components@add_battery_field_unismart
    components: [ wmbus ]
    refresh: 0d
```
Here is a proof-screenshot that it works fine.
<img width="1662" height="495" alt="battery_field_proof" src="https://github.com/user-attachments/assets/00489584-5107-4511-bbe8-1f7e3723a1cc" />

Partially fixed https://github.com/SzczepanLeon/esphome-components/issues/236

Also tried to get ```state``` and ```date``` fields working but ```text_sensor``` should be used instead as they are sensors without ```unit of measurement``` but its not supported in wmbus component

Here is example sensor configuration that may be added to docs:
```
sensors;
      - name: "UNISMART battery life"
        field: "battery"
        accuracy_decimals: 0
        unit_of_measurement: "d"
        device_class: "battery"
        state_class: "measurement"
        icon: "mdi:battery"
        entity_category: "diagnostic"
```