### PR TITLE
fix: undef HZ before defining Unit::HZ

### DIFF
--- a/components/wmbus_common/units.h
+++ b/components/wmbus_common/units.h
@@ -22,6 +22,13 @@
 #include <string>
 #include <vector>
 
+// TODO: There is a naming clash between ESP-IDF and following units.
+//       This is a hack which undef the ESP-IDF macro to allow ussage of wmbus
+//       defined unit.
+#ifdef HZ
+#undef HZ
+#endif
+
 // A named quantity has a preferred unit,
 // ie Volume has m3 (cubic meters) Energy has kwh, Power has kw.
 // We search for quantities in the mbus telegrams instead of


### PR DESCRIPTION
ESP-IDF headers often #define HZ, so our LIST_OF_UNITS macro blows up when it tries to emit the HZ enum entry (“expected identifier…”). For now we hack around this by `#ifdef HZ / #undef HZ` at the top of units.h so we can declare Unit::HZ without the macro clash. A cleaner long-term fix would be to rename the enum constant or isolate the system headers, but this unblock the current ESPHome build.