### PR TITLE
Add C1 link mode to Hydrus driver

### DIFF
--- a/components/wmbus/driver_hydrus.cpp
+++ b/components/wmbus/driver_hydrus.cpp
@@ -31,6 +31,7 @@ namespace
         di.setDefaultFields("name,id,total_m3,total_at_date_m3,status,timestamp");
         di.setMeterType(MeterType::WaterMeter);
         di.addLinkMode(LinkMode::T1);
+        di.addLinkMode(LinkMode::C1);
         di.addDetection(MANUFACTURER_DME,  0x07,  0x70);
         di.addDetection(MANUFACTURER_DME,  0x07,  0x76);
         di.addDetection(MANUFACTURER_HYD,  0x07,  0x24);


### PR DESCRIPTION
My Hydrus is transmitting C1 frames.

So I added the line

di.addLinkMode(LinkMode::C1);

to the file: driver_hydrus.cpp.
And now, I get all the data.

My RX is CC1101, so I use version_4.

I hope to get support for CC1101 in version_5 in the near future.


Here my log:


[10:43:39.723][C][wmbus:413]: wM-Bus v4.2.1-1.17.1-b8f4a945:
[10:43:39.736][C][wmbus:431]:   Chip ID: C40DFB38BCD8
[10:43:39.736][C][wmbus:433]:   CC1101 frequency: 868.950 MHz
[10:43:39.739][C][wmbus:434]:   CC1101 SPI bus:
[10:43:39.746][C][wmbus:438]:     MOSI Pin: GPIO23
[10:43:39.746][C][wmbus:439]:     MISO Pin: GPIO19
[10:43:39.753][C][wmbus:440]:     CLK Pin:  GPIO18
[10:43:39.755][C][wmbus:441]:     CS Pin:   GPIO22
[10:43:39.757][C][wmbus:442]:     GDO0 Pin: GPIO16
[10:43:39.769][C][wmbus:443]:     GDO2 Pin: GPIO17
[10:43:39.786][C][wmbus:449]:   Available drivers: wme5, weh_07, watertech, waterstarm, vario451mid, vario451, vario411, unknown, unismart, ultrimis, ultraheat, tsd2, topaseskr, supercom587, sontex868, sharky774, sharky, sensostar, rfmtx1, rfmamb, qwater, qualcosonic, qsmoke, qheat_55_us, qheat, qcaloric, q400, pollucomf, piigth, omnipower, nemo, munia, multical21, mkradio4a, mkradio4, mkradio3, minomess, microclima, lse_08, lse_07_17, lansenth, lansensm, lansenrp, lansenpu, lansendw, kampress, kamheat, izar, iwm
[10:43:39.803][C][wmbus:463]:   Meter:
[10:43:39.817][C][wmbus:464]:     ID: 2285127686 [0x88344806]
[10:43:39.835][C][wmbus:465]:     Type: hydrus
[10:43:39.835][C][wmbus:466]:     Key: '00112233445566778899AABBCCDDEEFF'
[10:43:39.836][C][wmbus:468]:     Field: 'flow_temperature'
[10:43:39.837][C][wmbus:017]:      Name: 'Hydrus Flow Temperature'
[10:43:39.837][C][wmbus:017]:        State Class: 'measurement'
[10:43:39.837][C][wmbus:017]:        Unit of Measurement: '°C'
[10:43:39.837][C][wmbus:017]:        Accuracy Decimals: 1
[10:43:39.849][C][wmbus:027]:        Device Class: 'temperature'
[10:43:39.855][C][wmbus:031]:        Icon: 'mdi:thermometer'
[10:43:39.857][C][wmbus:468]:     Field: 'remaining_battery_life'
[10:43:39.869][C][wmbus:017]:      Name: 'Hydrus Battery Life Remaining'
[10:43:39.869][C][wmbus:017]:        State Class: 'measurement'
[10:43:39.869][C][wmbus:017]:        Unit of Measurement: 'y'
[10:43:39.869][C][wmbus:017]:        Accuracy Decimals: 2
[10:43:39.869][C][wmbus:027]:        Device Class: 'battery'
[10:43:39.880][C][wmbus:468]:     Field: 'rssi'
[10:43:39.886][C][wmbus:017]:      Name: 'Hydrus RSSI'
[10:43:39.886][C][wmbus:017]:        State Class: 'measurement'
[10:43:39.886][C][wmbus:017]:        Unit of Measurement: 'dBm'
[10:43:39.886][C][wmbus:017]:        Accuracy Decimals: 0
[10:43:39.900][C][wmbus:027]:        Device Class: 'signal_strength'
[10:43:39.901][C][wmbus:468]:     Field: 'total'
[10:43:39.907][C][wmbus:017]:      Name: 'Hydrus Total Water Consumption'
[10:43:39.907][C][wmbus:017]:        State Class: 'total_increasing'
[10:43:39.907][C][wmbus:017]:        Unit of Measurement: 'm³'
[10:43:39.907][C][wmbus:017]:        Accuracy Decimals: 3
[10:43:39.928][C][wmbus:027]:        Device Class: 'water'
[10:43:39.928][C][wmbus:031]:        Icon: 'mdi:water'
[10:43:39.944][C][wmbus:472]:     Text field: 'status'
[10:43:39.948][C][wmbus:016]:      Name: 'Hydrus Status'
[10:43:40.347][D][mbus:014]: Received C1 A frame
[10:43:40.356][I][wmbus:094]: Using selected driver hydrus (detected driver was )
[10:43:40.358][I][wmbus:100]: hydrus [0x88344806] RSSI: -46dBm T: 5344A5110648348863078C003F900F002C2564AC0400E602871747F1D3217A3B003107101C3DDEC72741127B89B780D072FE7CC3CFB06156AD5D2FB02DD1C9BD723B17CF3A86A465188BC1047A2E604D4B3882EC (84) C1 A
[10:43:40.375][D][meters.cpp:1985]: (meter) created ESPHome hydrus 88344806 encrypted
[10:43:40.392][D][meters.cpp:909]: (meter) ESPHome(0) hydrus  handling telegram from 88344806.M=DME.V=63.T=07
[10:43:40.393][D][Telegram.cpp:563]: (telegram) ELL CI=8c CC=00 (slow_resp) ACC=3f
[10:43:40.393][D][Telegram.cpp:595]: (telegram) AFL CI=90
[10:43:40.419][D][sensor:133]: 'Hydrus Flow Temperature': Sending state 10.60000 °C with 1 decimals of accuracy
[10:43:40.431][D][sensor:133]: 'Hydrus Battery Life Remaining': Sending state 13.06529 y with 2 decimals of accuracy
[10:43:40.431][D][sensor:133]: 'Hydrus RSSI': Sending state -46.00000 dBm with 0 decimals of accuracy
[10:43:40.431][D][sensor:133]: 'Hydrus Total Water Consumption': Sending state 29.48800 m³ with 3 decimals of accuracy
[10:43:40.459][D][text_sensor:087]: 'Hydrus Status': Sending state 'OK'
[10:43:48.606][D][sensor:133]: 'WiFi Signal Percent': Sending state 80.00000 % with 0 decimals of accuracy
[10:43:49.966][D][sensor:133]: 'WiFi Signal dB': Sending state -59.00000 dBm with 0 decimals of accuracy
[10:43:59.531][D][mbus:014]: Received C1 A frame
[10:43:59.531][I][wmbus:094]: Using selected driver hydrus (detected driver was )
[10:43:59.531][I][wmbus:100]: hydrus [0x88344806] RSSI: -45dBm T: 5344A5110648348863078C003F900F002C2565AC04007989EC3691FC8CA37A3B00310710C19FCA59F03BF5CFEAF77B9E5658EC7BC910C7DFB7EC1148ED6C8B96B1415DD99F4AFFC6BE15BFB89FA7C02B36B11E5A (84) C1 A
[10:43:59.550][D][meters.cpp:1985]: (meter) created ESPHome hydrus 88344806 encrypted
[10:43:59.566][D][meters.cpp:909]: (meter) ESPHome(0) hydrus  handling telegram from 88344806.M=DME.V=63.T=07
[10:43:59.567][D][Telegram.cpp:563]: (telegram) ELL CI=8c CC=00 (slow_resp) ACC=3f
[10:43:59.567][D][Telegram.cpp:595]: (telegram) AFL CI=90
[10:43:59.595][D][sensor:133]: 'Hydrus Flow Temperature': Sending state 10.60000 °C with 1 decimals of accuracy
[10:43:59.595][D][sensor:133]: 'Hydrus Battery Life Remaining': Sending state 13.06529 y with 2 decimals of accuracy
[10:43:59.597][D][sensor:133]: 'Hydrus RSSI': Sending state -45.00000 dBm with 0 decimals of accuracy
[10:43:59.599][D][sensor:133]: 'Hydrus Total Water Consumption': Sending state 29.48800 m³ with 3 decimals of accuracy
[10:43:59.624][D][text_sensor:087]: 'Hydrus Status': Sending state 'OK'
[10:44:22.344][D][mbus:014]: Received C1 A frame
[10:44:22.367][I][wmbus:094]: Using selected driver hydrus (detected driver was )
[10:44:22.367][I][wmbus:100]: hydrus [0x88344806] RSSI: -46dBm T: 5344A5110648348863078C003F900F002C2566AC0400627FA9C37378DFEA7A3C00310710C71FDC36F74DC393B25D6C3173EB9250847724CCAA8AECD7C6AB5627B213209B982A7F74C8DF39C18A23B45DFD756BEE (84) C1 A
[10:44:22.367][D][meters.cpp:1985]: (meter) created ESPHome hydrus 88344806 encrypted
[10:44:22.381][D][meters.cpp:909]: (meter) ESPHome(0) hydrus  handling telegram from 88344806.M=DME.V=63.T=07
[10:44:22.382][D][Telegram.cpp:563]: (telegram) ELL CI=8c CC=00 (slow_resp) ACC=3f
[10:44:22.382][D][Telegram.cpp:595]: (telegram) AFL CI=90
[10:44:22.414][D][sensor:133]: 'Hydrus Flow Temperature': Sending state 10.50000 °C with 1 decimals of accuracy
[10:44:22.418][D][sensor:133]: 'Hydrus Battery Life Remaining': Sending state 13.06529 y with 2 decimals of accuracy
[10:44:22.452][D][sensor:133]: 'Hydrus RSSI': Sending state -46.00000 dBm with 0 decimals of accuracy
[10:44:22.452][D][sensor:133]: 'Hydrus Total Water Consumption': Sending state 29.48800 m³ with 3 decimals of accuracy
[10:44:22.452][D][text_sensor:087]: 'Hydrus Status': Sending state 'OK'


