### PR TITLE
Change play method to accept const references

### DIFF
--- a/components/socket_transmitter/socket_transmitter.h
+++ b/components/socket_transmitter/socket_transmitter.h
@@ -38,7 +38,9 @@ public:
 
   TEMPLATABLE_VALUE(StrOrVector, data)
 
-  void play(Ts... x) override { this->parent_->send(this->data_.value(x...)); }
+  void play(const Ts& ... x) override {
+    this->parent_->send(this->data_.value(x...));
+  }
 
 protected:
   SocketTransmitter *parent_;


### PR DESCRIPTION
ESPHome failed to compile, as signature of Action<T>::play() changed somewhen in 2024/2025 from

`virtual void play(Ts ... x)`

to

`virtual void play(const Ts& ... x) = 0;`

See: [ESPHome Developer Documentation](https://developers.esphome.io/blog/2025/11/06/action-framework-performance-optimization)