### PR TITLE
Add CC1101 radio transceiver support

### DIFF
--- a/components/wmbus_radio/transceiver_cc1101.cpp
+++ b/components/wmbus_radio/transceiver_cc1101.cpp
@@ -1,0 +1,275 @@
+#include "transceiver_cc1101.h"
+
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace wmbus_radio {
+static const char *TAG = "CC1101";
+
+// CC1101 crystal frequency (standard 26 MHz)
+#define F_XTAL 26000000
+
+void CC1101::setup() {
+  this->common_setup();
+
+  ESP_LOGV(TAG, "Setup");
+  ESP_LOGVV(TAG, "reset");
+  this->reset();
+
+  // Software reset via SRES strobe
+  ESP_LOGVV(TAG, "software reset");
+  this->strobe(CC1101_SRES);
+  delay(10);
+
+  ESP_LOGVV(TAG, "checking part number");
+  uint8_t partnum = this->read_status_register(CC1101_PARTNUM);
+  uint8_t version = this->read_status_register(CC1101_VERSION);
+  ESP_LOGVV(TAG, "part: %02X, version: %02X", partnum, version);
+  if (partnum != 0x00) {
+    ESP_LOGE(TAG, "Invalid part number: %02X (expected 0x00)", partnum);
+    return;
+  }
+
+  // Configure for wM-Bus Mode C/T at 868.95 MHz, 100 kbps, 2-FSK
+  // RF settings based on TI Design Note DN022 and wmbusmeters reference
+
+  ESP_LOGVV(TAG, "configuring GDO pins");
+  // GDO2: Sync word sent/received (active low, inverted)
+  this->write_register(CC1101_IOCFG2, CC1101_GDO_SYNC_WORD | 0x40);
+  // GDO1: High impedance (unused, default)
+  this->write_register(CC1101_IOCFG1, CC1101_GDO_HI_Z);
+  // GDO0: RXFIFO threshold reached (IRQ pin), active low (inverted)
+  this->write_register(CC1101_IOCFG0, CC1101_GDO_RXFIFO_THR | 0x40);
+
+  ESP_LOGVV(TAG, "configuring FIFO threshold");
+  // FIFO threshold: 7 = RX FIFO >= 32 bytes, TX FIFO <= 31 bytes
+  this->write_register(CC1101_FIFOTHR, 0x07);
+
+  ESP_LOGVV(TAG, "configuring sync word");
+  // Sync word for wM-Bus: 0x543D (with Manchester encoding: preamble 0x54)
+  this->write_register(CC1101_SYNC1, WMBUS_SYNC_WORD_HIGH);
+  this->write_register(CC1101_SYNC0, WMBUS_SYNC_WORD_LOW);
+
+  ESP_LOGVV(TAG, "configuring packet control");
+  // Packet length: 0xFF for infinite/variable
+  this->write_register(CC1101_PKTLEN, 0xFF);
+  // Packet control 1: No address check, no append status, no CRC autoflush
+  this->write_register(CC1101_PKTCTRL1, 0x00);
+  // Packet control 0: Variable packet length, no whitening, no CRC
+  this->write_register(CC1101_PKTCTRL0, 0x00);
+
+  // No device address filtering
+  this->write_register(CC1101_ADDR, 0x00);
+  // Channel number 0
+  this->write_register(CC1101_CHANNR, 0x00);
+
+  ESP_LOGVV(TAG, "configuring frequency synthesizer");
+  // IF frequency: ~152 kHz (typical for 100 kbps)
+  this->write_register(CC1101_FSCTRL1, 0x08);
+  this->write_register(CC1101_FSCTRL0, 0x00);
+
+  ESP_LOGVV(TAG, "setting radio frequency");
+  // Frequency: 868.95 MHz
+  // FREQ = (f_carrier * 2^16) / f_xtal = (868950000 * 65536) / 26000000 = 0x216BD0
+  const uint32_t frequency = 868950000;
+  uint32_t freq_reg = ((uint64_t)frequency << 16) / F_XTAL;
+  this->write_register(CC1101_FREQ2, BYTE(freq_reg, 2));
+  this->write_register(CC1101_FREQ1, BYTE(freq_reg, 1));
+  this->write_register(CC1101_FREQ0, BYTE(freq_reg, 0));
+
+  ESP_LOGVV(TAG, "configuring modem");
+  // Modem configuration for 100 kbps, 2-FSK, 50 kHz deviation
+  // MDMCFG4: Channel bandwidth and data rate exponent
+  // BW = f_xtal / (8 * (4 + CHANBW_M) * 2^CHANBW_E) = 26M / (8 * 4 * 4) = ~203 kHz
+  this->write_register(CC1101_MDMCFG4, 0x5C);
+  // MDMCFG3: Data rate mantissa
+  // DRATE = ((256 + DRATE_M) * 2^DRATE_E) * f_xtal / 2^28 = 100 kbps
+  this->write_register(CC1101_MDMCFG3, 0x04);
+  // MDMCFG2: Modulation format (2-FSK), sync mode (16/16 sync word bits)
+  this->write_register(CC1101_MDMCFG2, 0x06);
+  // MDMCFG1: FEC disabled, preamble 4 bytes
+  this->write_register(CC1101_MDMCFG1, 0x22);
+  // MDMCFG0: Channel spacing exponent
+  this->write_register(CC1101_MDMCFG0, 0xF8);
+
+  ESP_LOGVV(TAG, "configuring deviation");
+  // Deviation: ~50 kHz
+  // DEVIATION = (f_xtal / 2^17) * (8 + DEVIATION_M) * 2^DEVIATION_E
+  this->write_register(CC1101_DEVIATN, 0x44);
+
+  ESP_LOGVV(TAG, "configuring state machine");
+  // MCSM2: RX time qualifier enabled
+  this->write_register(CC1101_MCSM2, 0x07);
+  // MCSM1: CCA mode, RX after RX, IDLE after TX
+  this->write_register(CC1101_MCSM1, 0x00);
+  // MCSM0: Auto calibrate from IDLE to RX/TX, PO timeout
+  this->write_register(CC1101_MCSM0, 0x18);
+
+  ESP_LOGVV(TAG, "configuring AFC/AGC");
+  // FOCCFG: Frequency offset compensation
+  this->write_register(CC1101_FOCCFG, 0x2E);
+  // BSCFG: Bit synchronization
+  this->write_register(CC1101_BSCFG, 0xBF);
+  // AGC control
+  this->write_register(CC1101_AGCCTRL2, 0x43);
+  this->write_register(CC1101_AGCCTRL1, 0x09);
+  this->write_register(CC1101_AGCCTRL0, 0xB5);
+
+  ESP_LOGVV(TAG, "configuring WOR");
+  // Wake-on-Radio: disabled (but configured for compatibility)
+  this->write_register(CC1101_WOREVT1, 0x87);
+  this->write_register(CC1101_WOREVT0, 0x6B);
+  this->write_register(CC1101_WORCTRL, 0xFB);
+
+  ESP_LOGVV(TAG, "configuring front end");
+  // Front end RX: LNA and mixer current
+  this->write_register(CC1101_FREND1, 0xB6);
+  // Front end TX: PA power index
+  this->write_register(CC1101_FREND0, 0x10);
+
+  ESP_LOGVV(TAG, "configuring frequency calibration");
+  // Frequency synthesizer calibration
+  this->write_register(CC1101_FSCAL3, 0xEA);
+  this->write_register(CC1101_FSCAL2, 0x2A);
+  this->write_register(CC1101_FSCAL1, 0x00);
+  this->write_register(CC1101_FSCAL0, 0x1F);
+
+  // RC oscillator configuration
+  this->write_register(CC1101_RCCTRL1, 0x41);
+  this->write_register(CC1101_RCCTRL0, 0x00);
+
+  ESP_LOGVV(TAG, "configuring test registers");
+  // Test registers for optimal performance
+  this->write_register(CC1101_FSTEST, 0x59);
+  this->write_register(CC1101_PTEST, 0x7F);
+  this->write_register(CC1101_AGCTEST, 0x3F);
+  this->write_register(CC1101_TEST2, 0x81);
+  this->write_register(CC1101_TEST1, 0x35);
+  this->write_register(CC1101_TEST0, 0x09);
+
+  ESP_LOGVV(TAG, "calibrating");
+  // Calibrate frequency synthesizer
+  this->strobe(CC1101_SCAL);
+  delay(1);
+
+  ESP_LOGVV(TAG, "entering RX mode");
+  // Flush RX FIFO and enter RX mode
+  this->strobe(CC1101_SFRX);
+  this->strobe(CC1101_SRX);
+
+  ESP_LOGV(TAG, "CC1101 setup done");
+}
+
+uint8_t CC1101::strobe(uint8_t cmd) {
+  this->delegate_->begin_transaction();
+  uint8_t status = this->delegate_->transfer(cmd);
+  this->delegate_->end_transaction();
+  return status;
+}
+
+uint8_t CC1101::read_register(uint8_t address) {
+  this->delegate_->begin_transaction();
+  this->delegate_->transfer(address | CC1101_READ_SINGLE);
+  uint8_t value = this->delegate_->transfer(0x00);
+  this->delegate_->end_transaction();
+  return value;
+}
+
+uint8_t CC1101::read_status_register(uint8_t address) {
+  this->delegate_->begin_transaction();
+  this->delegate_->transfer(address | CC1101_READ_BURST);
+  uint8_t value = this->delegate_->transfer(0x00);
+  this->delegate_->end_transaction();
+  return value;
+}
+
+void CC1101::write_register(uint8_t address, uint8_t value) {
+  this->delegate_->begin_transaction();
+  this->delegate_->transfer(address | CC1101_WRITE_SINGLE);
+  this->delegate_->transfer(value);
+  this->delegate_->end_transaction();
+}
+
+void CC1101::write_burst(uint8_t address, const uint8_t *data, size_t length) {
+  this->delegate_->begin_transaction();
+  this->delegate_->transfer(address | CC1101_WRITE_BURST);
+  for (size_t i = 0; i < length; i++) {
+    this->delegate_->transfer(data[i]);
+  }
+  this->delegate_->end_transaction();
+}
+
+void CC1101::read_burst(uint8_t address, uint8_t *data, size_t length) {
+  this->delegate_->begin_transaction();
+  this->delegate_->transfer(address | CC1101_READ_BURST);
+  for (size_t i = 0; i < length; i++) {
+    data[i] = this->delegate_->transfer(0x00);
+  }
+  this->delegate_->end_transaction();
+}
+
+uint8_t CC1101::get_rx_bytes() {
+  return this->read_status_register(CC1101_RXBYTES) & 0x7F;
+}
+
+optional<uint8_t> CC1101::read() {
+  // Check if IRQ pin indicates data available (active low = FIFO threshold reached)
+  if (this->irq_pin_->digital_read() == false) {
+    uint8_t rx_bytes = this->get_rx_bytes();
+    if (rx_bytes > 0) {
+      // Read RSSI before reading data byte (RSSI is valid after sync word)
+      this->last_rssi_ = (int8_t)this->read_status_register(CC1101_RSSI);
+
+      // Read single byte from RX FIFO
+      uint8_t data;
+      this->read_burst(CC1101_RXFIFO, &data, 1);
+      return data;
+    }
+  }
+  return {};
+}
+
+size_t CC1101::get_frame(uint8_t *buffer, size_t length, uint32_t offset) {
+  // CC1101 reads byte-by-byte from FIFO (offset is ignored for FIFO-based reading)
+  // Returns 1 on success, 0 if FIFO is empty (waiting for more data)
+  auto byte = this->read();
+  if (!byte.has_value())
+    return 0;
+
+  *buffer = *byte;
+  return 1;
+}
+
+void CC1101::restart_rx() {
+  ESP_LOGVV(TAG, "Restarting RX");
+
+  // Go to IDLE state
+  this->strobe(CC1101_SIDLE);
+  delay(1);
+
+  // Flush RX FIFO
+  this->strobe(CC1101_SFRX);
+
+  // Enter RX mode
+  this->strobe(CC1101_SRX);
+  delay(1);
+}
+
+int8_t CC1101::get_rssi() {
+  // Convert RSSI_dec to dBm
+  // RSSI_dBm = (RSSI_dec / 2) - RSSI_offset
+  // RSSI_offset is typically 74 for 868 MHz
+  int8_t rssi_dec = this->last_rssi_;
+  int16_t rssi_dbm;
+  if (rssi_dec >= 128) {
+    rssi_dbm = ((int16_t)(rssi_dec - 256) / 2) - 74;
+  } else {
+    rssi_dbm = (rssi_dec / 2) - 74;
+  }
+  return (int8_t)rssi_dbm;
+}
+
+const char *CC1101::get_name() { return TAG; }
+
+} // namespace wmbus_radio
+} // namespace esphome

--- a/components/wmbus_radio/transceiver_cc1101.h
+++ b/components/wmbus_radio/transceiver_cc1101.h
@@ -1,0 +1,187 @@
+#pragma once
+#include "transceiver.h"
+
+// CC1101 SPI command strobes
+#define CC1101_SRES         0x30  // Reset chip
+#define CC1101_SFSTXON      0x31  // Enable and calibrate frequency synthesizer
+#define CC1101_SXOFF        0x32  // Turn off crystal oscillator
+#define CC1101_SCAL         0x33  // Calibrate frequency synthesizer
+#define CC1101_SRX          0x34  // Enable RX
+#define CC1101_STX          0x35  // Enable TX
+#define CC1101_SIDLE        0x36  // Exit RX/TX, turn off frequency synthesizer
+#define CC1101_SWOR         0x38  // Start automatic RX polling sequence
+#define CC1101_SPWD         0x39  // Enter power down mode
+#define CC1101_SFRX         0x3A  // Flush the RX FIFO
+#define CC1101_SFTX         0x3B  // Flush the TX FIFO
+#define CC1101_SWORRST      0x3C  // Reset real time clock to Event1 value
+#define CC1101_SNOP         0x3D  // No operation
+
+// CC1101 configuration registers
+#define CC1101_IOCFG2       0x00  // GDO2 output pin configuration
+#define CC1101_IOCFG1       0x01  // GDO1 output pin configuration
+#define CC1101_IOCFG0       0x02  // GDO0 output pin configuration
+#define CC1101_FIFOTHR      0x03  // RX FIFO and TX FIFO thresholds
+#define CC1101_SYNC1        0x04  // Sync word, high byte
+#define CC1101_SYNC0        0x05  // Sync word, low byte
+#define CC1101_PKTLEN       0x06  // Packet length
+#define CC1101_PKTCTRL1     0x07  // Packet automation control
+#define CC1101_PKTCTRL0     0x08  // Packet automation control
+#define CC1101_ADDR         0x09  // Device address
+#define CC1101_CHANNR       0x0A  // Channel number
+#define CC1101_FSCTRL1      0x0B  // Frequency synthesizer control
+#define CC1101_FSCTRL0      0x0C  // Frequency synthesizer control
+#define CC1101_FREQ2        0x0D  // Frequency control word, high byte
+#define CC1101_FREQ1        0x0E  // Frequency control word, middle byte
+#define CC1101_FREQ0        0x0F  // Frequency control word, low byte
+#define CC1101_MDMCFG4      0x10  // Modem configuration
+#define CC1101_MDMCFG3      0x11  // Modem configuration
+#define CC1101_MDMCFG2      0x12  // Modem configuration
+#define CC1101_MDMCFG1      0x13  // Modem configuration
+#define CC1101_MDMCFG0      0x14  // Modem configuration
+#define CC1101_DEVIATN      0x15  // Modem deviation setting
+#define CC1101_MCSM2        0x16  // Main Radio Control State Machine configuration
+#define CC1101_MCSM1        0x17  // Main Radio Control State Machine configuration
+#define CC1101_MCSM0        0x18  // Main Radio Control State Machine configuration
+#define CC1101_FOCCFG       0x19  // Frequency Offset Compensation configuration
+#define CC1101_BSCFG        0x1A  // Bit Synchronization configuration
+#define CC1101_AGCCTRL2     0x1B  // AGC control
+#define CC1101_AGCCTRL1     0x1C  // AGC control
+#define CC1101_AGCCTRL0     0x1D  // AGC control
+#define CC1101_WOREVT1      0x1E  // High byte Event0 timeout
+#define CC1101_WOREVT0      0x1F  // Low byte Event0 timeout
+#define CC1101_WORCTRL      0x20  // Wake On Radio control
+#define CC1101_FREND1       0x21  // Front end RX configuration
+#define CC1101_FREND0       0x22  // Front end TX configuration
+#define CC1101_FSCAL3       0x23  // Frequency synthesizer calibration
+#define CC1101_FSCAL2       0x24  // Frequency synthesizer calibration
+#define CC1101_FSCAL1       0x25  // Frequency synthesizer calibration
+#define CC1101_FSCAL0       0x26  // Frequency synthesizer calibration
+#define CC1101_RCCTRL1      0x27  // RC oscillator configuration
+#define CC1101_RCCTRL0      0x28  // RC oscillator configuration
+#define CC1101_FSTEST       0x29  // Frequency synthesizer calibration control
+#define CC1101_PTEST        0x2A  // Production test
+#define CC1101_AGCTEST      0x2B  // AGC test
+#define CC1101_TEST2        0x2C  // Various test settings
+#define CC1101_TEST1        0x2D  // Various test settings
+#define CC1101_TEST0        0x2E  // Various test settings
+
+// CC1101 status registers (read with burst bit set)
+#define CC1101_PARTNUM      0x30  // Part number
+#define CC1101_VERSION      0x31  // Current version number
+#define CC1101_FREQEST      0x32  // Frequency offset estimate
+#define CC1101_LQI          0x33  // Demodulator estimate for link quality
+#define CC1101_RSSI         0x34  // Received signal strength indication
+#define CC1101_MARCSTATE    0x35  // Control state machine state
+#define CC1101_WORTIME1     0x36  // High byte of WOR timer
+#define CC1101_WORTIME0     0x37  // Low byte of WOR timer
+#define CC1101_PKTSTATUS    0x38  // Current GDOx status and packet status
+#define CC1101_VCO_VC_DAC   0x39  // Current setting from PLL calibration module
+#define CC1101_TXBYTES      0x3A  // Underflow and number of bytes in TX FIFO
+#define CC1101_RXBYTES      0x3B  // Overflow and number of bytes in RX FIFO
+#define CC1101_RCCTRL1_STATUS 0x3C  // Last RC oscillator calibration result
+#define CC1101_RCCTRL0_STATUS 0x3D  // Last RC oscillator calibration result
+
+// CC1101 FIFO access
+#define CC1101_TXFIFO       0x3F  // TX FIFO (write)
+#define CC1101_RXFIFO       0x3F  // RX FIFO (read)
+
+// CC1101 SPI access masks
+#define CC1101_WRITE_SINGLE 0x00
+#define CC1101_WRITE_BURST  0x40
+#define CC1101_READ_SINGLE  0x80
+#define CC1101_READ_BURST   0xC0
+
+// MARCSTATE values
+#define CC1101_MARCSTATE_SLEEP          0x00
+#define CC1101_MARCSTATE_IDLE           0x01
+#define CC1101_MARCSTATE_XOFF           0x02
+#define CC1101_MARCSTATE_VCOON_MC       0x03
+#define CC1101_MARCSTATE_REGON_MC       0x04
+#define CC1101_MARCSTATE_MANCAL         0x05
+#define CC1101_MARCSTATE_VCOON          0x06
+#define CC1101_MARCSTATE_REGON          0x07
+#define CC1101_MARCSTATE_STARTCAL       0x08
+#define CC1101_MARCSTATE_BWBOOST        0x09
+#define CC1101_MARCSTATE_FS_LOCK        0x0A
+#define CC1101_MARCSTATE_IFADCON        0x0B
+#define CC1101_MARCSTATE_ENDCAL         0x0C
+#define CC1101_MARCSTATE_RX             0x0D
+#define CC1101_MARCSTATE_RX_END         0x0E
+#define CC1101_MARCSTATE_RX_RST         0x0F
+#define CC1101_MARCSTATE_TXRX_SWITCH    0x10
+#define CC1101_MARCSTATE_RXFIFO_OVERFLOW 0x11
+#define CC1101_MARCSTATE_FSTXON         0x12
+#define CC1101_MARCSTATE_TX             0x13
+#define CC1101_MARCSTATE_TX_END         0x14
+#define CC1101_MARCSTATE_RXTX_SWITCH    0x15
+#define CC1101_MARCSTATE_TXFIFO_UNDERFLOW 0x16
+
+// GDOx configuration values (for IOCFG0/1/2)
+#define CC1101_GDO_RXFIFO_THR           0x00  // Associated to RXFIFO threshold
+#define CC1101_GDO_RXFIFO_FULL          0x01  // RXFIFO full
+#define CC1101_GDO_TXFIFO_THR           0x02  // Associated to TXFIFO threshold
+#define CC1101_GDO_TXFIFO_FULL          0x03  // TXFIFO full
+#define CC1101_GDO_RXFIFO_OVERFLOW      0x04  // RXFIFO overflow
+#define CC1101_GDO_TXFIFO_UNDERFLOW     0x05  // TXFIFO underflow
+#define CC1101_GDO_SYNC_WORD            0x06  // Sync word sent/received
+#define CC1101_GDO_PKT_RECEIVED         0x07  // Packet received with CRC OK
+#define CC1101_GDO_PREAMBLE_QUALITY     0x08  // Preamble quality reached
+#define CC1101_GDO_CCA                  0x09  // Clear channel assessment
+#define CC1101_GDO_PLL_LOCK             0x0A  // PLL lock signal
+#define CC1101_GDO_SERIAL_CLK           0x0B  // Serial synchronous data clock
+#define CC1101_GDO_SERIAL_SYNC_DATA     0x0C  // Serial synchronous data output
+#define CC1101_GDO_SERIAL_ASYNC_DATA    0x0D  // Serial asynchronous data output
+#define CC1101_GDO_CARRIER_SENSE        0x0E  // Carrier sense
+#define CC1101_GDO_CRC_OK               0x0F  // CRC_OK
+#define CC1101_GDO_HI_Z                 0x2E  // High impedance (tri-state)
+#define CC1101_GDO_CLK_XOSC_1           0x30  // Clock output XOSC/1
+#define CC1101_GDO_CLK_XOSC_1_5         0x31  // Clock output XOSC/1.5
+#define CC1101_GDO_CLK_XOSC_2           0x32  // Clock output XOSC/2
+#define CC1101_GDO_CLK_XOSC_3           0x33  // Clock output XOSC/3
+#define CC1101_GDO_CLK_XOSC_4           0x34  // Clock output XOSC/4
+#define CC1101_GDO_CLK_XOSC_6           0x35  // Clock output XOSC/6
+#define CC1101_GDO_CLK_XOSC_8           0x36  // Clock output XOSC/8
+#define CC1101_GDO_CLK_XOSC_12          0x37  // Clock output XOSC/12
+#define CC1101_GDO_CLK_XOSC_16          0x38  // Clock output XOSC/16
+#define CC1101_GDO_CLK_XOSC_24          0x39  // Clock output XOSC/24
+#define CC1101_GDO_CLK_XOSC_32          0x3A  // Clock output XOSC/32
+#define CC1101_GDO_CLK_XOSC_48          0x3B  // Clock output XOSC/48
+#define CC1101_GDO_CLK_XOSC_64          0x3C  // Clock output XOSC/64
+#define CC1101_GDO_CLK_XOSC_96          0x3D  // Clock output XOSC/96
+#define CC1101_GDO_CLK_XOSC_128         0x3E  // Clock output XOSC/128
+#define CC1101_GDO_CLK_XOSC_192         0x3F  // Clock output XOSC/192
+
+// wM-Bus specific defines
+#define WMBUS_SYNC_WORD_HIGH            0x54
+#define WMBUS_SYNC_WORD_LOW             0x3D
+#define WMBUS_PREAMBLE                  0x54
+
+namespace esphome {
+namespace wmbus_radio {
+
+class CC1101 : public RadioTransceiver {
+public:
+  void setup() override;
+  size_t get_frame(uint8_t *buffer, size_t length, uint32_t offset) override;
+  gpio::InterruptType get_interrupt_type() override { return gpio::INTERRUPT_FALLING_EDGE; }
+  void restart_rx() override;
+  int8_t get_rssi() override;
+  const char *get_name() override;
+
+protected:
+  optional<uint8_t> read() override;
+
+  // CC1101-specific SPI methods
+  uint8_t strobe(uint8_t cmd);
+  uint8_t read_register(uint8_t address);
+  uint8_t read_status_register(uint8_t address);
+  void write_register(uint8_t address, uint8_t value);
+  void write_burst(uint8_t address, const uint8_t *data, size_t length);
+  void read_burst(uint8_t address, uint8_t *data, size_t length);
+  uint8_t get_rx_bytes();
+
+  int8_t last_rssi_{0};
+};
+
+} // namespace wmbus_radio
+} // namespace esphome


### PR DESCRIPTION
## Summary
- Add driver for the TI CC1101 sub-1 GHz radio transceiver
- Enables wM-Bus Mode C/T reception at 868.95 MHz (100 kbps, 2-FSK)
- Implements the same `RadioTransceiver` interface used by SX1262 and SX1276

## Test plan
- [ ] Verify CC1101 is detected via SPI (part number check)
- [ ] Confirm wM-Bus packet reception at 868.95 MHz
- [ ] Validate RSSI readings

🤖 Generated with [Claude Code](https://claude.com/claude-code)