### PR TITLE
Fix drivers config to convert list input to set

### DIFF
--- a/components/wmbus_common/__init__.py
+++ b/components/wmbus_common/__init__.py
@@ -28,7 +28,7 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(WMBusCommon),
         cv.Optional(CONF_DRIVERS, default=set()): cv.All(
-            lambda x: AVAILABLE_DRIVERS if x == "all" else x,
+            lambda x: AVAILABLE_DRIVERS if x == "all" else set(x) if isinstance(x, list) else x,
             {validate_driver},
         ),
     }


### PR DESCRIPTION
## Summary
- When a YAML list is provided for the `drivers` config option, it arrives as a Python list. Previously, only the `"all"` shorthand was handled, and a raw list would be passed through without conversion to a set, causing validation issues.
- This adds `set(x) if isinstance(x, list)` to properly convert list input before validation.

## Test plan
- [ ] Configure `drivers` with a YAML list (e.g., `drivers: [izar, amiplus]`) and verify it compiles correctly
- [ ] Verify `drivers: all` still works
- [ ] Verify `drivers: {izar, amiplus}` (set syntax) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)