### PR TITLE
Use FILTER_SOURCE_FILES to exclude unused drivers and transceivers

### DIFF
--- a/components/wmbus_common/__init__.py
+++ b/components/wmbus_common/__init__.py
@@ -1,6 +1,5 @@
 import esphome.config_validation as cv
 from esphome.const import SOURCE_FILE_EXTENSIONS, CONF_ID
-from esphome.loader import get_component, ComponentManifest
 from esphome import codegen as cg
 from pathlib import Path
 
@@ -10,6 +9,8 @@ CONF_DRIVERS = "drivers"
 wmbus_common_ns = cg.esphome_ns.namespace("wmbus_common")
 WMBusCommon = wmbus_common_ns.class_("WMBusCommon", cg.Component)
 
+# Enable .cc files to be picked up as source files (wmbusmeters library uses .cc)
+SOURCE_FILE_EXTENSIONS.add(".cc")
 
 AVAILABLE_DRIVERS = {
     f.stem.removeprefix("driver_") for f in Path(__file__).parent.glob("driver_*.cc")
@@ -35,23 +36,11 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-class WMBusComponentManifest(ComponentManifest):
-    exclude_drivers: set[str]
-
-    @property
-    def resources(self):
-        exclude_files = {f"driver_{name}.cc" for name in self.exclude_drivers}
-        SOURCE_FILE_EXTENSIONS.add(".cc")
-        resources = [fr for fr in super(
-        ).resources if fr.resource not in exclude_files]
-        SOURCE_FILE_EXTENSIONS.discard(".cc")
-        return resources
+def FILTER_SOURCE_FILES():
+    """Return set of driver source files to exclude from compilation."""
+    return {f"driver_{name}.cc" for name in AVAILABLE_DRIVERS - _registered_drivers}
 
 
 async def to_code(config):
-    component = get_component("wmbus_common")
-    component.__class__ = WMBusComponentManifest
-    component.exclude_drivers = AVAILABLE_DRIVERS - _registered_drivers
-
     var = cg.new_Pvariable(config[CONF_ID], sorted(_registered_drivers))
     await cg.register_component(var, config)


### PR DESCRIPTION
## Summary
- Replace the fragile `WMBusComponentManifest` class-swap hack in `wmbus_common` with ESPHome's official `FILTER_SOURCE_FILES()` hook to exclude unused `driver_*.cc` files from compilation
- Add `FILTER_SOURCE_FILES()` to `wmbus_radio` to exclude unused `transceiver_*.cpp/.h` files based on the configured `radio_type`
- Move `SOURCE_FILE_EXTENSIONS.add(".cc")` to module level so `.cc` files are always recognized as source files

## Test plan
- [ ] Compile with `drivers: [multical21]` and `radio_type: CC1101` — verify only `driver_multical21.cc` and `transceiver_cc1101.cpp` are compiled
- [ ] Compile with `drivers: all` — verify all driver files are compiled
- [ ] Compile with `radio_type: SX1262` — verify only `transceiver_sx1262.cpp` is compiled
- [ ] Verify firmware runs correctly on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)