### PR TITLE
backport CRC checking fix for long B-frames from upstream

### DIFF
--- a/components/wmbus_common/wmbus.cc
+++ b/components/wmbus_common/wmbus.cc
@@ -4946,7 +4946,9 @@ bool trimCRCsFrameFormatBInternal(std::vector<uchar> &payload,
     crc2_pos = len - 2;
   }
 
-  uint16_t calc_crc = crc16_EN13757(safeButUnsafeVectorPtr(payload), crc1_pos);
+  uchar *from1 = &payload[0];
+  size_t len1 = crc1_pos;
+  uint16_t calc_crc = crc16_EN13757(from1, len1);
   uint16_t check_crc = payload[crc1_pos] << 8 | payload[crc1_pos + 1];
 
   if (calc_crc != check_crc && !FUZZING) {
@@ -4964,7 +4966,9 @@ bool trimCRCsFrameFormatBInternal(std::vector<uchar> &payload,
   }
 
   if (crc2_pos > 0) {
-    calc_crc = crc16_EN13757(&payload[crc1_pos + 2], crc2_pos);
+    uchar *from2 = &payload[crc1_pos+2];
+    size_t len2 = crc2_pos-crc1_pos-2;
+    calc_crc = crc16_EN13757(from2, len2);
     check_crc = payload[crc2_pos] << 8 | payload[crc2_pos + 1];
 
     if (calc_crc != check_crc && !FUZZING) {


### PR DESCRIPTION
Upstream commit wmbusmeters/wmbusmeters@6b7e7bfa698627b8607051084faf653b3a41f958 .

This fixes bug #338 .