### PR TITLE
Add CC1101 bulk FIFO reader with errata workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Version 5 based on Kuba's dirty [fork](https://github.com/IoTLabs-pl/esphome-com
 
 
 # TODO:
-- Add backward support for CC1101
 - Prepare packages for ready made boards (like UltimateReader) with displays, leds etc.
 - Aggresive cleanup of wmbusmeters classes/structs
 - Refactor traces/logs
 
 # DONE:
+- Add CC1101 support with FIFO overflow handling and errata workaround
 - Add support for SX1262 (with limited frame length)
 - Reuse CRCs and frame parsers from wmbusmeters
 - Refactor 3out6 decoder
@@ -190,6 +190,23 @@ text_sensor:
 ```
 
 ## Radio Configuration
+
+### CC1101
+For CC1101 radio, configure the SPI bus and specify the chip select and IRQ (GDO0) pins. The CC1101 has no hardware reset pin — it uses a software reset (SRES strobe) automatically. See [ESP32-C3_SuperMini_CC1101.yaml](ESP32-C3_SuperMini_CC1101.yaml) for a complete working example.
+
+```yaml
+spi:
+  clk_pin: GPIO5
+  mosi_pin: GPIO6
+  miso_pin: GPIO7
+
+wmbus_radio:
+  radio_type: CC1101
+  cs_pin: GPIO4
+  irq_pin: GPIO3
+```
+
+Tested on ESP32-C3 Super Mini + CC1101 v2.0 (E07-M1101D-SMA) blue board.
 
 ### SX1276
 For SX1276 radio you need to configure SPI instance as usual in ESPHome and additionally specify reset pin and IRQ pin (as DIO1). Interrupts are triggered on non empty FIFO.

--- a/components/wmbus_radio/transceiver.h
+++ b/components/wmbus_radio/transceiver.h
@@ -51,7 +51,7 @@ public:
   // SX1262: returns length (entire buffer at once)
   virtual size_t get_frame(uint8_t *buffer, size_t length, uint32_t offset) { return 0; }
 
-  bool read_in_task(uint8_t *buffer, size_t length, uint32_t offset);
+  virtual bool read_in_task(uint8_t *buffer, size_t length, uint32_t offset);
 
   void set_spi(spi::SPIDelegate *spi);
   void set_reset_pin(GPIOPin *reset_pin);

--- a/components/wmbus_radio/transceiver_cc1101.cpp
+++ b/components/wmbus_radio/transceiver_cc1101.cpp
@@ -269,5 +269,63 @@ int8_t CC1101::get_rssi() {
 
 const char *CC1101::get_name() { return TAG; }
 
+bool CC1101::read_in_task(uint8_t *buffer, size_t length, uint32_t offset) {
+  size_t total = 0;
+  uint32_t last_progress = millis();
+
+  while (total < length) {
+    // Check for FIFO overflow
+    uint8_t rxbytes_raw = this->read_status_register(CC1101_RXBYTES);
+    if (rxbytes_raw & 0x80) {
+      ESP_LOGW(TAG, "RX FIFO overflow");
+      this->restart_rx();
+      return false;
+    }
+
+    uint8_t available = rxbytes_raw & 0x7F;
+    size_t remaining = length - total;
+
+    if (available > 0) {
+      // CC1101 errata: don't empty FIFO completely when more data expected
+      size_t to_read = (remaining > 1 && available > 1)
+                       ? std::min((size_t)(available - 1), remaining)
+                       : std::min((size_t)available, remaining);
+
+      if (to_read > 0) {
+        if (total == 0 && offset == 0) {
+          this->last_rssi_ = (int8_t)this->read_status_register(CC1101_RSSI);
+        }
+        this->read_burst(CC1101_RXFIFO, buffer + total, to_read);
+        total += to_read;
+        last_progress = millis();
+      }
+    }
+
+    // Check end-of-packet via MARCSTATE (IDLE or RX_END = packet done)
+    if (total > 0 && total < length) {
+      uint8_t marcstate = this->read_status_register(CC1101_MARCSTATE) & 0x1F;
+      if (marcstate == CC1101_MARCSTATE_IDLE || marcstate == CC1101_MARCSTATE_RX_END) {
+        // Packet finished, drain remaining FIFO
+        uint8_t final_bytes = this->read_status_register(CC1101_RXBYTES) & 0x7F;
+        if (final_bytes > 0 && total + final_bytes <= length) {
+          this->read_burst(CC1101_RXFIFO, buffer + total, final_bytes);
+          total += final_bytes;
+        }
+        break;
+      }
+    }
+
+    // Timeout: 500ms without progress
+    if (millis() - last_progress > 500) {
+      ESP_LOGW(TAG, "RX timeout after %zu bytes (need %zu)", total + offset, length + offset);
+      return false;
+    }
+
+    delayMicroseconds(200);
+  }
+
+  return (total == length);
+}
+
 } // namespace wmbus_radio
 } // namespace esphome

--- a/components/wmbus_radio/transceiver_cc1101.h
+++ b/components/wmbus_radio/transceiver_cc1101.h
@@ -163,6 +163,7 @@ class CC1101 : public RadioTransceiver {
 public:
   void setup() override;
   size_t get_frame(uint8_t *buffer, size_t length, uint32_t offset) override;
+  bool read_in_task(uint8_t *buffer, size_t length, uint32_t offset) override;
   gpio::InterruptType get_interrupt_type() override { return gpio::INTERRUPT_FALLING_EDGE; }
   void restart_rx() override;
   int8_t get_rssi() override;


### PR DESCRIPTION
## Summary
- Add CC1101-specific `read_in_task()` override with FIFO overflow detection, the CC1101 "don't empty FIFO" errata workaround, MARCSTATE-based end-of-packet detection, and a 500ms progress timeout
- Make `read_in_task` virtual in the base `RadioTransceiver` class so CC1101 can override it (SX1276/SX1262 are unaffected — they use the base implementation)
- Update README.md with CC1101 configuration section and example reference

## Background
The CC1101's FIFO has a known silicon errata where reading the last byte while more data is incoming can corrupt the FIFO. The base `read_in_task()` uses a generic byte-by-byte approach that doesn't handle this. The new CC1101 override reads `available - 1` bytes to work around the errata, detects FIFO overflow, and uses the MARCSTATE register to detect end-of-packet.

## Tested on
- **MCU**: ESP32-C3 Super Mini
- **Radio**: CC1101 v2.0 blue board (E07-M1101D-SMA)
- **Meter**: Kamstrup MULTICAL 21 water meter (wM-Bus Mode C1, 868.95 MHz)
- **Framework**: ESP-IDF, ESPHome 2026.2.4

## Test plan
- [x] Device boots and CC1101 initializes
- [x] WiFi connects and ESPHome API reports sensor data
- [x] SX1276/SX1262 unaffected (base `read_in_task` unchanged, now virtual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)