### PR TITLE
Add configurable frequency for CC1101 (300–928 MHz)

### DIFF
--- a/ESP32-C3_SuperMini_CC1101.yaml
+++ b/ESP32-C3_SuperMini_CC1101.yaml
@@ -72,6 +72,7 @@ wmbus_radio:
   radio_type: CC1101
   cs_pin: GPIO4
   irq_pin: GPIO3
+  # frequency: 868.95MHz   # Optional. Range: 300–928 MHz. Default: 868.95 MHz
   on_frame:
     - then:
         - logger.log:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Version 5 based on Kuba's dirty [fork](https://github.com/IoTLabs-pl/esphome-com
 - Refactor traces/logs
 
 # DONE:
+- Add configurable frequency for CC1101 (300–928 MHz, default 868.95 MHz)
 - Add CC1101 support with FIFO overflow handling and errata workaround
 - Add support for SX1262 (with limited frame length)
 - Reuse CRCs and frame parsers from wmbusmeters
@@ -204,7 +205,15 @@ wmbus_radio:
   radio_type: CC1101
   cs_pin: GPIO4
   irq_pin: GPIO3
+  frequency: 868.95MHz   # Optional. Range: 300–928 MHz. Default: 868.95 MHz
 ```
+
+| Option | Required | Default | Description |
+|---|---|---|---|
+| `radio_type` | yes | — | Must be `CC1101` |
+| `cs_pin` | yes | — | SPI chip select pin |
+| `irq_pin` | yes | — | Interrupt pin (GDO0) |
+| `frequency` | no | `868.95MHz` | Operating frequency, 300–928 MHz |
 
 Tested on ESP32-C3 Super Mini + CC1101 v2.0 (E07-M1101D-SMA) blue board.
 

--- a/components/wmbus_radio/__init__.py
+++ b/components/wmbus_radio/__init__.py
@@ -27,6 +27,7 @@ CONF_ON_FRAME = "on_frame"
 CONF_RADIO_TYPE = "radio_type"
 CONF_MARK_AS_HANDLED = "mark_as_handled"
 CONF_BUSY_PIN = "busy_pin"
+CONF_FREQUENCY = "frequency"
 CONF_RX_GAIN = "rx_gain"
 CONF_RF_SWITCH = "rf_switch"
 CONF_SYNC_MODE = "sync_mode"
@@ -87,6 +88,11 @@ CONFIG_SCHEMA = (
             cv.Required(CONF_IRQ_PIN): pins.internal_gpio_input_pin_schema,
             # Optional BUSY pin for SX1262
             cv.Optional(CONF_BUSY_PIN): pins.gpio_input_pin_schema,
+            # Operating frequency (CC1101 only). Range: 300–928 MHz. Default: 868.95 MHz
+            cv.Optional(CONF_FREQUENCY, default="868.95MHz"): cv.All(
+                cv.frequency,
+                cv.Range(min=300e6, max=928e6),
+            ),
             # Optional RX gain mode for SX1262 (default: BOOSTED for better sensitivity)
             cv.Optional(CONF_RX_GAIN, default="BOOSTED"): cv.one_of(
                 *RX_GAIN_OPTIONS, upper=True
@@ -131,6 +137,9 @@ async def to_code(config):
     if CONF_BUSY_PIN in config:
         busy_pin = await cg.gpio_pin_expression(config[CONF_BUSY_PIN])
         cg.add(radio_var.set_busy_pin(busy_pin))
+
+    # Operating frequency
+    cg.add(radio_var.set_frequency_hz(int(config[CONF_FREQUENCY])))
 
     # RX gain mode
     cg.add(radio_var.set_rx_gain_mode(RX_GAIN_OPTIONS[config[CONF_RX_GAIN]]))

--- a/components/wmbus_radio/transceiver.cpp
+++ b/components/wmbus_radio/transceiver.cpp
@@ -34,6 +34,10 @@ void RadioTransceiver::set_busy_pin(GPIOPin *busy_pin) {
   this->busy_pin_ = busy_pin;
 }
 
+void RadioTransceiver::set_frequency_hz(uint32_t hz) {
+  this->frequency_hz_ = hz;
+}
+
 void RadioTransceiver::set_rx_gain_mode(const std::string &mode) {
   if (mode == "RX_GAIN_BOOSTED") {
     this->rx_gain_mode_ = RX_GAIN_BOOSTED;
@@ -156,6 +160,7 @@ void RadioTransceiver::dump_config() {
   if (this->busy_pin_ != nullptr) {
     LOG_PIN("  BUSY Pin: ", this->busy_pin_);
   }
+  ESP_LOGCONFIG(TAG, "  Frequency: %.3f MHz", this->frequency_hz_ / 1e6f);
   ESP_LOGCONFIG(TAG, "  RX Gain: %s",
                 this->rx_gain_mode_ == RX_GAIN_BOOSTED ? "Boosted" : "Power Saving");
   if (this->rf_switch_) {

--- a/components/wmbus_radio/transceiver.h
+++ b/components/wmbus_radio/transceiver.h
@@ -57,6 +57,7 @@ public:
   void set_reset_pin(GPIOPin *reset_pin);
   void set_irq_pin(InternalGPIOPin *irq_pin);
   void set_busy_pin(GPIOPin *busy_pin);
+  void set_frequency_hz(uint32_t hz);
   void set_rx_gain_mode(const std::string &mode);
   void set_rf_switch(bool enable);
   void set_sync_mode(const std::string &mode);
@@ -66,6 +67,7 @@ protected:
   GPIOPin *reset_pin_{nullptr};
   InternalGPIOPin *irq_pin_{nullptr};
   GPIOPin *busy_pin_{nullptr};  // Optional, used by SX1262
+  uint32_t frequency_hz_{868950000};  // Default: 868.95 MHz
   RxGainMode rx_gain_mode_{RX_GAIN_BOOSTED};
   bool rf_switch_{false};  // Use DIO2 as RF switch control (SX1262)
   SyncMode sync_mode_{SYNC_MODE_NORMAL};

--- a/components/wmbus_radio/transceiver_cc1101.cpp
+++ b/components/wmbus_radio/transceiver_cc1101.cpp
@@ -67,10 +67,8 @@ void CC1101::setup() {
   this->write_register(CC1101_FSCTRL0, 0x00);
 
   ESP_LOGVV(TAG, "setting radio frequency");
-  // Frequency: 868.95 MHz
-  // FREQ = (f_carrier * 2^16) / f_xtal = (868950000 * 65536) / 26000000 = 0x216BD0
-  const uint32_t frequency = 868950000;
-  uint32_t freq_reg = ((uint64_t)frequency << 16) / F_XTAL;
+  // FREQ = (f_carrier * 2^16) / f_xtal
+  uint32_t freq_reg = ((uint64_t)this->frequency_hz_ << 16) / F_XTAL;
   this->write_register(CC1101_FREQ2, BYTE(freq_reg, 2));
   this->write_register(CC1101_FREQ1, BYTE(freq_reg, 1));
   this->write_register(CC1101_FREQ0, BYTE(freq_reg, 0));
@@ -254,15 +252,15 @@ void CC1101::restart_rx() {
 }
 
 int8_t CC1101::get_rssi() {
-  // Convert RSSI_dec to dBm
-  // RSSI_dBm = (RSSI_dec / 2) - RSSI_offset
-  // RSSI_offset is typically 74 for 868 MHz
+  // Convert RSSI_dec to dBm: RSSI_dBm = (RSSI_dec / 2) - RSSI_offset
+  // RSSI offset per TI DN505: 74 dBm for 868 MHz, 76 dBm for 433 MHz
+  int8_t rssi_offset = (this->frequency_hz_ < 600000000u) ? 76 : 74;
   int8_t rssi_dec = this->last_rssi_;
   int16_t rssi_dbm;
   if (rssi_dec >= 128) {
-    rssi_dbm = ((int16_t)(rssi_dec - 256) / 2) - 74;
+    rssi_dbm = ((int16_t)(rssi_dec - 256) / 2) - rssi_offset;
   } else {
-    rssi_dbm = (rssi_dec / 2) - 74;
+    rssi_dbm = (rssi_dec / 2) - rssi_offset;
   }
   return (int8_t)rssi_dbm;
 }


### PR DESCRIPTION
## Summary

- Adds an optional `frequency` parameter to `wmbus_radio` for the CC1101 transceiver
- Accepts any value in the 300–928 MHz range; defaults to `868.95MHz` (EU wM-Bus)
- RSSI offset is automatically adjusted based on band (74 dBm ≥600 MHz, 76 dBm <600 MHz) per TI DN505
- SX1276 and SX1262 are unaffected — the member is in the base class but their `setup()` keeps the hardcoded 868.95 MHz value
- Updates README with parameter table and example YAML

## Usage

```yaml
wmbus_radio:
  radio_type: CC1101
  cs_pin: GPIO4
  irq_pin: GPIO3
  frequency: 433.82MHz   # optional, defaults to 868.95MHz
```

## Test plan

- [ ] Build with default (no `frequency` key) — should compile and behave as before
- [ ] Build with `frequency: 868.95MHz` explicitly — same result
- [ ] Build with `frequency: 433.82MHz` — verify registers and RSSI offset change
- [ ] Build with out-of-range value (e.g. `200MHz`) — should fail validation at config time

> **Note:** Non-default frequencies have not been tested in the field. No device broadcasting on 433/434 MHz is available to verify reception end-to-end. The register calculation and RSSI offset logic are based on the CC1101 datasheet and TI DN505, but real-world validation is still needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)