### PR TITLE
Fix stack overflow on ESP32-S3 with large encrypted wmbus telegrams

### DIFF
--- a/components/wmbus_common/meters.cc
+++ b/components/wmbus_common/meters.cc
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <memory>
 #include <memory.h>
 #include <numeric>
 #include <stdexcept>
@@ -758,7 +759,8 @@ std::string concatFields(Meter *m, Telegram *t, char c,
 bool MeterCommonImplementation::handleTelegram(
     AboutTelegram &about, std::vector<uchar> input_frame, bool simulated,
     std::vector<Address> *addresses, bool *id_match, Telegram *out_analyzed) {
-  Telegram t;
+  std::unique_ptr<Telegram> tp(new Telegram());
+  Telegram &t = *tp;
   t.about = about;
   bool ok = t.parseHeader(input_frame);
 

--- a/components/wmbus_common/wmbus_utils.cc
+++ b/components/wmbus_common/wmbus_utils.cc
@@ -75,7 +75,7 @@ bool decrypt_ELL_AES_CTR(Telegram *t, std::vector<uchar> &frame,
     AES_ECB_encrypt(iv, safeButUnsafeVectorPtr(aeskey), xordata, 16);
 
     // Xor the data with the pseudo-random bits to decrypt into tmp.
-    uchar tmp[block_size];
+    uchar tmp[16];
     xorit(xordata, &encrypted_bytes[offset], tmp, block_size);
 
     debug("(ELL) block %d block_size %d offset %zu\n", block, block_size,
@@ -195,19 +195,19 @@ bool decrypt_TPL_AES_CBC_IV(Telegram *t, std::vector<uchar> &frame,
   std::string s = bin2hex(ivv);
   debug("(TPL) IV %s\n", s.c_str());
 
-  uchar buffer_data[num_bytes_to_decrypt];
-  memcpy(buffer_data, safeButUnsafeVectorPtr(buffer), num_bytes_to_decrypt);
-  uchar decrypted_data[num_bytes_to_decrypt];
+  std::vector<uchar> buffer_data(num_bytes_to_decrypt);
+  memcpy(buffer_data.data(), safeButUnsafeVectorPtr(buffer), num_bytes_to_decrypt);
+  std::vector<uchar> decrypted_data(num_bytes_to_decrypt);
 
-  AES_CBC_decrypt_buffer(decrypted_data, buffer_data, num_bytes_to_decrypt,
+  AES_CBC_decrypt_buffer(decrypted_data.data(), buffer_data.data(), num_bytes_to_decrypt,
                          safeButUnsafeVectorPtr(aeskey), iv);
 
   // Remove the encrypted bytes.
   frame.erase(pos, frame.end());
 
   // Insert the decrypted bytes.
-  frame.insert(frame.end(), decrypted_data,
-               decrypted_data + num_bytes_to_decrypt);
+  frame.insert(frame.end(), decrypted_data.begin(),
+               decrypted_data.begin() + num_bytes_to_decrypt);
 
   debugPayload("(TPL) decrypted ", frame, pos);
 
@@ -273,19 +273,19 @@ bool decrypt_TPL_AES_CBC_NO_IV(Telegram *t, std::vector<uchar> &frame,
   std::string s = bin2hex(ivv);
   debug("(TPL) IV %s\n", s.c_str());
 
-  uchar buffer_data[num_bytes_to_decrypt];
-  memcpy(buffer_data, safeButUnsafeVectorPtr(buffer), num_bytes_to_decrypt);
-  uchar decrypted_data[num_bytes_to_decrypt];
+  std::vector<uchar> buffer_data(num_bytes_to_decrypt);
+  memcpy(buffer_data.data(), safeButUnsafeVectorPtr(buffer), num_bytes_to_decrypt);
+  std::vector<uchar> decrypted_data(num_bytes_to_decrypt);
 
-  AES_CBC_decrypt_buffer(decrypted_data, buffer_data, num_bytes_to_decrypt,
+  AES_CBC_decrypt_buffer(decrypted_data.data(), buffer_data.data(), num_bytes_to_decrypt,
                          safeButUnsafeVectorPtr(aeskey), iv);
 
   // Remove the encrypted bytes and any potentially not decryptes bytes after.
   frame.erase(pos, frame.end());
 
   // Insert the decrypted bytes.
-  frame.insert(frame.end(), decrypted_data,
-               decrypted_data + num_bytes_to_decrypt);
+  frame.insert(frame.end(), decrypted_data.begin(),
+               decrypted_data.begin() + num_bytes_to_decrypt);
 
   debugPayload("(TPL) decrypted ", frame, pos);
 


### PR DESCRIPTION
Full disclosure: This is AI-assisted, tested for a couple of days on the device - working stable.

Problem:
On ESP32-S3 (and other constrained targets), processing large encrypted wmbus telegrams causes a stack overflow in loopTask. Two root causes:

1. wmbus_utils.cc: decrypt_TPL_AES_CBC_IV() and decrypt_TPL_AES_CBC_NO_IV() use C99 Variable Length Arrays (VLA) for the decryption buffers:

     uchar buffer_data[num_bytes_to_decrypt];
     uchar decrypted_data[num_bytes_to_decrypt];

   For large telegrams (e.g. amiplus electricity meter sends 245-byte frames, requiring ~220 bytes of encrypted payload), these VLAs consume ~440 bytes of stack per call. On ESP32-S3 with loopTask already near its stack limit due to WiFi + BLE + wmbus coexistence, this causes a crash.

   Additionally, decrypt_ELL_AES_CTR() had uchar tmp[block_size] where block_size is a runtime variable — also a VLA, replaced with uchar tmp[16] since the code already asserts block_size <= 16.

2. meters.cc: handleTelegram() allocates a Telegram object on the stack:

     Telegram t;

   The Telegram struct contains multiple std::vector, std::map and std::string members with significant stack overhead from their constructors and internal state. Moving it to the heap frees several KB of stack during telegram processing.

Fix:
- Replace VLAs in wmbus_utils.cc with std::vector<uchar> (heap allocation)
- Replace stack-allocated Telegram in meters.cc with std::unique_ptr<Telegram>
- Add #include <memory> to meters.cc for std::unique_ptr

Tested on: Heltec WiFi LoRa 32 V3 (ESP32-S3FN8) with:
- amiplus electricity meter (245-byte encrypted T1 frames)
- apator162 water meter
- 4x Xiaomi LYWSDCGQ BLE sensors
- WiFi + BLE active simultaneously