### PR TITLE
Fix CC1101 packet length limit in PKTCTRL0

### DIFF
--- a/components/wmbus_radio/transceiver_cc1101.cpp
+++ b/components/wmbus_radio/transceiver_cc1101.cpp
@@ -54,7 +54,7 @@ void CC1101::setup() {
   // Packet control 1: No address check, no append status, no CRC autoflush
   this->write_register(CC1101_PKTCTRL1, 0x00);
   // Packet control 0: Variable packet length, no whitening, no CRC
-  this->write_register(CC1101_PKTCTRL0, 0x00);
+  this->write_register(CC1101_PKTCTRL0, 0x02);
 
   // No device address filtering
   this->write_register(CC1101_ADDR, 0x00);


### PR DESCRIPTION
Changed LENGTH_CONFIG from 00 (fixed) to 10 (infinite) in PKTCTRL0 register.

Previously, the setting 0x00 limited packet length to 255 bytes, causing truncation and CRC failures for longer packets. Using infinite mode (0x02) allows the host to control reception duration, which is correct for handling packets larger than the FIFO limit or the previous 255-byte ceiling.

Issues https://github.com/SzczepanLeon/esphome-components/issues/406