### PR TITLE
Rename PrintProperty STATUS enumerator to fix ESP-IDF toolchain builds

### DIFF
--- a/components/wmbus_common/driver_abbb23.cc
+++ b/components/wmbus_common/driver_abbb23.cc
@@ -39,7 +39,7 @@ namespace
       addStringField(
             "status",
             "Status, error, warning and alarm flags.",
-            DEFAULT_PRINT_PROPERTIES | PrintProperty::INCLUDE_TPL_STATUS | PrintProperty::STATUS);
+            DEFAULT_PRINT_PROPERTIES | PrintProperty::INCLUDE_TPL_STATUS | PrintProperty::STATUS_FIELD);
 
         addNumericFieldWithExtractor(
             "total_energy_consumption",

--- a/components/wmbus_common/driver_aventieshca.cc
+++ b/components/wmbus_common/driver_aventieshca.cc
@@ -39,7 +39,7 @@ namespace
         addStringFieldWithExtractorAndLookup(
             "status",
             "Meter status from error flags and tpl status field.",
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(MeasurementType::Instantaneous)
             .set(VIFRange::ErrorFlags),

--- a/components/wmbus_common/driver_aventieswm.cc
+++ b/components/wmbus_common/driver_aventieswm.cc
@@ -40,7 +40,7 @@ namespace
         addStringFieldWithExtractorAndLookup(
             "status",
             "Meter status from error flags and tpl status field.",
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(MeasurementType::Instantaneous)
             .set(VIFRange::ErrorFlags),

--- a/components/wmbus_common/driver_c5isf.cc
+++ b/components/wmbus_common/driver_c5isf.cc
@@ -94,7 +94,7 @@ namespace
         addStringFieldWithExtractorAndLookup(
             "status",
             "Status and error flags.",
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(VIFRange::ErrorFlags),
             {

--- a/components/wmbus_common/driver_cma12w.cc
+++ b/components/wmbus_common/driver_cma12w.cc
@@ -44,7 +44,7 @@ namespace
         addStringField(
             "status",
             "Meter status from tpl status field.",
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS);
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS);
 
         addNumericFieldWithExtractor(
             "current_temperature",

--- a/components/wmbus_common/driver_dme_07.cc
+++ b/components/wmbus_common/driver_dme_07.cc
@@ -39,7 +39,7 @@ namespace
         addStringFieldWithExtractorAndLookup(
             "status",
             "Status of meter.",
-            DEFAULT_PRINT_PROPERTIES  | PrintProperty::STATUS,
+            DEFAULT_PRINT_PROPERTIES  | PrintProperty::STATUS_FIELD,
             FieldMatcher::build()
             .set(MeasurementType::Instantaneous)
             .set(VIFRange::ErrorFlags),

--- a/components/wmbus_common/driver_ehzp.cc
+++ b/components/wmbus_common/driver_ehzp.cc
@@ -38,7 +38,7 @@ namespace
         addStringField(
             "status",
             "Meter status. Includes both meter error field and tpl status field.",
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS);
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS);
 
         addOptionalLibraryFields("on_time_h");
 

--- a/components/wmbus_common/driver_ei6500.cc
+++ b/components/wmbus_common/driver_ei6500.cc
@@ -46,7 +46,7 @@ namespace
         addStringFieldWithExtractorAndLookup(
             "status",
             "Meter error flags. IMPORTANT! Smoke alarm is NOT reported here! You MUST check last alarm date and counter!",
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(VIFRange::ErrorFlags),
             Translate::Lookup(

--- a/components/wmbus_common/driver_elf.cc
+++ b/components/wmbus_common/driver_elf.cc
@@ -38,7 +38,7 @@ namespace
         addStringFieldWithExtractorAndLookup(
             "status",
             "Meter status from manufacturer status and tpl status field.",
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(DifVifKey("047F")),
             {

--- a/components/wmbus_common/driver_em24.cc
+++ b/components/wmbus_common/driver_em24.cc
@@ -45,7 +45,7 @@ namespace
         addStringFieldWithExtractorAndLookup(
             "status",
             "Status of meter.",
-            DEFAULT_PRINT_PROPERTIES | PrintProperty::STATUS,
+            DEFAULT_PRINT_PROPERTIES | PrintProperty::STATUS_FIELD,
             FieldMatcher::build()
             .set(MeasurementType::Instantaneous)
             .set(VIFRange::ErrorFlags),

--- a/components/wmbus_common/driver_enercal.cc
+++ b/components/wmbus_common/driver_enercal.cc
@@ -38,7 +38,7 @@ namespace
         addStringField(
             "status",
             "Meter status.",
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS);
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS);
 
         addNumericFieldWithExtractor(
             "total",

--- a/components/wmbus_common/driver_engelmann-faw.cc
+++ b/components/wmbus_common/driver_engelmann-faw.cc
@@ -40,7 +40,7 @@ namespace
         addStringFieldWithExtractorAndLookup(
             "status",
             "Status and error flags.",
-            DEFAULT_PRINT_PROPERTIES  | PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            DEFAULT_PRINT_PROPERTIES  | PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(VIFRange::ErrorFlags),
             {

--- a/components/wmbus_common/driver_eurisii.cc
+++ b/components/wmbus_common/driver_eurisii.cc
@@ -41,7 +41,7 @@ namespace
             "status",
             "Meter status from error flags and tpl status field.",
             DEFAULT_PRINT_PROPERTIES  |
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(MeasurementType::Instantaneous)
             .set(VIFRange::ErrorFlags),
@@ -69,7 +69,7 @@ namespace
             "error_flags",
             "Deprecated field! Use status instead.",
             DEFAULT_PRINT_PROPERTIES | PrintProperty::DEPRECATED |
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(MeasurementType::Instantaneous)
             .set(VIFRange::ErrorFlags),

--- a/components/wmbus_common/driver_evo868.cc
+++ b/components/wmbus_common/driver_evo868.cc
@@ -44,7 +44,7 @@ namespace
             "current_status",
             "Status of meter.",
             DEFAULT_PRINT_PROPERTIES
-            | PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            | PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(MeasurementType::Instantaneous)
             .set(VIFRange::ErrorFlags),

--- a/components/wmbus_common/driver_fhkvdataiv.cc
+++ b/components/wmbus_common/driver_fhkvdataiv.cc
@@ -43,7 +43,7 @@ namespace
             "status",
             "Meter status from tpl status field.",
             DEFAULT_PRINT_PROPERTIES  |
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS);
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS);
 
         addNumericFieldWithExtractor(
             "current_consumption",

--- a/components/wmbus_common/driver_flowiq2200.cc
+++ b/components/wmbus_common/driver_flowiq2200.cc
@@ -44,7 +44,7 @@ namespace
         addStringFieldWithExtractorAndLookup(
             "status",
             "Status of meter. Not fully understood!",
-            DEFAULT_PRINT_PROPERTIES | PrintProperty::STATUS,
+            DEFAULT_PRINT_PROPERTIES | PrintProperty::STATUS_FIELD,
             FieldMatcher::build()
             .set(DifVifKey("04FF23")),
             {

--- a/components/wmbus_common/driver_gransystems.cc
+++ b/components/wmbus_common/driver_gransystems.cc
@@ -62,7 +62,7 @@ namespace
         addStringFieldWithExtractorAndLookup(
             "status",
             "Status of meter.",
-            DEFAULT_PRINT_PROPERTIES | PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            DEFAULT_PRINT_PROPERTIES | PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(MeasurementType::Instantaneous)
             .set(VIFRange::ErrorFlags),

--- a/components/wmbus_common/driver_gwfwater.cc
+++ b/components/wmbus_common/driver_gwfwater.cc
@@ -44,7 +44,7 @@ namespace
         addStringField(
             "status",
             "Meter status.",
-            PrintProperty::INCLUDE_TPL_STATUS | PrintProperty::STATUS);
+            PrintProperty::INCLUDE_TPL_STATUS | PrintProperty::STATUS_FIELD);
 
         addStringField(
             "mfct_status",

--- a/components/wmbus_common/driver_hcae2.cc
+++ b/components/wmbus_common/driver_hcae2.cc
@@ -41,7 +41,7 @@ namespace
             "status",
             "Meter status from error flags and tpl status field.",
             DEFAULT_PRINT_PROPERTIES  |
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(MeasurementType::Instantaneous)
             .set(VIFRange::ErrorFlags),

--- a/components/wmbus_common/driver_hydrocalm3.cc
+++ b/components/wmbus_common/driver_hydrocalm3.cc
@@ -48,7 +48,7 @@ namespace
             "status",
             "Meter status from tpl status field.",
             DEFAULT_PRINT_PROPERTIES  |
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS);
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS);
 
         addNumericFieldWithExtractor(
             "total_heating",

--- a/components/wmbus_common/driver_hydrus.cc
+++ b/components/wmbus_common/driver_hydrus.cc
@@ -50,7 +50,7 @@ namespace
         addStringField(
             "status",
             "Status of meter.",
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS);
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS);
 
         addNumericFieldWithExtractor(
             "total",

--- a/components/wmbus_common/driver_iem3000.cc
+++ b/components/wmbus_common/driver_iem3000.cc
@@ -43,7 +43,7 @@ namespace
         addStringField(
             "status",
             "Status and error flags.",
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS);
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS);
 
         addStringFieldWithExtractorAndLookup(
             "error_flags",

--- a/components/wmbus_common/driver_itron.cc
+++ b/components/wmbus_common/driver_itron.cc
@@ -51,7 +51,7 @@ namespace
         addStringFieldWithExtractorAndLookup(
             "status",
             "Status and error flags.",
-            DEFAULT_PRINT_PROPERTIES  | PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            DEFAULT_PRINT_PROPERTIES  | PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(MeasurementType::Instantaneous)
             .set(VIFRange::ErrorFlags)

--- a/components/wmbus_common/driver_iwmtx5.cc
+++ b/components/wmbus_common/driver_iwmtx5.cc
@@ -44,7 +44,7 @@ namespace
         addStringField(
             "status",
             "Status and error flags.",
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS);
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS);
     }
 }
 

--- a/components/wmbus_common/driver_kamheat.cc
+++ b/components/wmbus_common/driver_kamheat.cc
@@ -66,7 +66,7 @@ namespace
         addStringFieldWithExtractorAndLookup(
             "status",
             "Status and error flags.",
-            DEFAULT_PRINT_PROPERTIES | PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            DEFAULT_PRINT_PROPERTIES | PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(DifVifKey("04FF22")),
             Translate::Lookup(

--- a/components/wmbus_common/driver_lansendw.cc
+++ b/components/wmbus_common/driver_lansendw.cc
@@ -53,7 +53,7 @@ namespace
         addStringFieldWithExtractorAndLookup(
             "error_flags",
             "Error flags.",
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(MeasurementType::Instantaneous)
             .set(VIFRange::ErrorFlags),

--- a/components/wmbus_common/driver_lansenpu.cc
+++ b/components/wmbus_common/driver_lansenpu.cc
@@ -48,7 +48,7 @@ namespace
             "status",
             "Meter status from tpl status field.",
             DEFAULT_PRINT_PROPERTIES   |
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS);
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS);
 
         /* Doubles have a 52 bit significand 11 bit exp and 1 bit sign,
            so double is good for incremental pulses up to 2^52 counts

--- a/components/wmbus_common/driver_lansenrp.cc
+++ b/components/wmbus_common/driver_lansenrp.cc
@@ -49,7 +49,7 @@ namespace
             "status",
             "Meter status from tpl status field.",
             DEFAULT_PRINT_PROPERTIES   |
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS);
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS);
 
         addNumericFieldWithExtractor(
             "total_routed_messages",

--- a/components/wmbus_common/driver_lansensm.cc
+++ b/components/wmbus_common/driver_lansensm.cc
@@ -40,7 +40,7 @@ namespace
             "status",
             "Meter status.",
             DEFAULT_PRINT_PROPERTIES   |
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(VIFRange::ErrorFlags)
             .add(VIFCombinable::StandardConformantDataContent),

--- a/components/wmbus_common/driver_lansenth.cc
+++ b/components/wmbus_common/driver_lansenth.cc
@@ -48,7 +48,7 @@ namespace
             "status",
             "Meter status from tpl status field.",
             DEFAULT_PRINT_PROPERTIES   |
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS);
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS);
 
         addNumericFieldWithExtractor(
             "current_temperature",

--- a/components/wmbus_common/driver_lse_08.cc
+++ b/components/wmbus_common/driver_lse_08.cc
@@ -43,7 +43,7 @@ namespace
             "status",
             "Meter status from tpl status field.",
             DEFAULT_PRINT_PROPERTIES   |
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(DifVifKey("01FD73")),
             Translate::Lookup(

--- a/components/wmbus_common/driver_microclima.cc
+++ b/components/wmbus_common/driver_microclima.cc
@@ -43,7 +43,7 @@ namespace
             "status",
             "Meter status from error flags and tpl status field.",
             DEFAULT_PRINT_PROPERTIES  |
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(MeasurementType::Instantaneous)
             .set(VIFRange::ErrorFlags),

--- a/components/wmbus_common/driver_multical21.cc
+++ b/components/wmbus_common/driver_multical21.cc
@@ -42,7 +42,7 @@ namespace
         addStringFieldWithExtractorAndLookup(
             "status",
             "Status of meter.",
-            DEFAULT_PRINT_PROPERTIES  | PrintProperty::STATUS,
+            DEFAULT_PRINT_PROPERTIES  | PrintProperty::STATUS_FIELD,
             FieldMatcher::build()
             .set(DifVifKey("02FF20")),
             Translate::Lookup()

--- a/components/wmbus_common/driver_munia.cc
+++ b/components/wmbus_common/driver_munia.cc
@@ -40,7 +40,7 @@ namespace
             "status",
             "Meter status. Reports OK if neither tpl sts nor error flags have bits set.",
             DEFAULT_PRINT_PROPERTIES   |
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(DifVifKey("02FD971D")),
             Translate::Lookup({

--- a/components/wmbus_common/driver_nemo.cc
+++ b/components/wmbus_common/driver_nemo.cc
@@ -169,7 +169,7 @@ namespace
         addStringFieldWithExtractorAndLookup(
             "status",
             "Status. OK if no error flags are set.",
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(MeasurementType::Instantaneous)
             .set(VIFRange::ErrorFlags),

--- a/components/wmbus_common/driver_piigth.cc
+++ b/components/wmbus_common/driver_piigth.cc
@@ -41,7 +41,7 @@ namespace
         addStringField(
             "status",
             "Meter status from tpl status field.",
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS);
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS);
 
         addNumericFieldWithExtractor(
             "temperature",

--- a/components/wmbus_common/driver_pollucomf.cc
+++ b/components/wmbus_common/driver_pollucomf.cc
@@ -41,7 +41,7 @@ namespace
             "status",
             "Meter status.",
             DEFAULT_PRINT_PROPERTIES   |
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS);
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS);
 
         addNumericFieldWithExtractor(
             "total",

--- a/components/wmbus_common/driver_q400.cc
+++ b/components/wmbus_common/driver_q400.cc
@@ -42,7 +42,7 @@ namespace
         addStringField(
             "status",
             "Status and error flags.",
-            DEFAULT_PRINT_PROPERTIES | PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS);
+            DEFAULT_PRINT_PROPERTIES | PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS);
 
         addStringFieldWithExtractor(
             "set_datetime",

--- a/components/wmbus_common/driver_qcaloric.cc
+++ b/components/wmbus_common/driver_qcaloric.cc
@@ -51,7 +51,7 @@ namespace
             "status",
             "Meter status from tpl status field.",
             DEFAULT_PRINT_PROPERTIES   |
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(DifVifKey("01FD73")),
             Translate::Lookup(

--- a/components/wmbus_common/driver_qheat.cc
+++ b/components/wmbus_common/driver_qheat.cc
@@ -46,7 +46,7 @@ namespace
         addStringFieldWithExtractorAndLookup(
             "status",
             "Meter status.",
-            DEFAULT_PRINT_PROPERTIES  | PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            DEFAULT_PRINT_PROPERTIES  | PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(MeasurementType::Instantaneous)
             .set(VIFRange::ErrorFlags),

--- a/components/wmbus_common/driver_qsmoke.cc
+++ b/components/wmbus_common/driver_qsmoke.cc
@@ -41,7 +41,7 @@ namespace
             "status",
             "Meter error flags. IMPORTANT! Smoke alarm is probably NOT reported here! You MUST check last alarm date and counter!",
             DEFAULT_PRINT_PROPERTIES   |
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(VIFRange::ErrorFlags),
             Translate::Lookup(

--- a/components/wmbus_common/driver_qualcosonic.cc
+++ b/components/wmbus_common/driver_qualcosonic.cc
@@ -45,7 +45,7 @@ namespace
             "status",
             "Meter status. Includes both meter error field and tpl status field.",
             DEFAULT_PRINT_PROPERTIES   |
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(VIFRange::ErrorFlags),
             Translate::Lookup(

--- a/components/wmbus_common/driver_qwater.cc
+++ b/components/wmbus_common/driver_qwater.cc
@@ -64,7 +64,7 @@ namespace
         addStringField(
             "status",
             "Meter status tpl status field.",
-            DEFAULT_PRINT_PROPERTIES | PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS);
+            DEFAULT_PRINT_PROPERTIES | PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS);
 
         addNumericFieldWithExtractor(
             "due_date",

--- a/components/wmbus_common/driver_rfmamb.cc
+++ b/components/wmbus_common/driver_rfmamb.cc
@@ -40,7 +40,7 @@ namespace
             "status",
             "Meter status from tpl status field.",
             DEFAULT_PRINT_PROPERTIES  |
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS);
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS);
 
         addNumericFieldWithExtractor(
             "current_temperature",

--- a/components/wmbus_common/driver_sharky.cc
+++ b/components/wmbus_common/driver_sharky.cc
@@ -46,7 +46,7 @@ namespace
         addStringFieldWithExtractorAndLookup(
             "status",
             "Status of meter.",
-            DEFAULT_PRINT_PROPERTIES  | PrintProperty::STATUS,
+            DEFAULT_PRINT_PROPERTIES  | PrintProperty::STATUS_FIELD,
             FieldMatcher::build()
             .set(MeasurementType::Instantaneous)
             .set(VIFRange::ErrorFlags),

--- a/components/wmbus_common/driver_supercom587.cc
+++ b/components/wmbus_common/driver_supercom587.cc
@@ -43,7 +43,7 @@ namespace
         addStringFieldWithExtractorAndLookup(
             "status",
             "Status of meter.",
-            DEFAULT_PRINT_PROPERTIES | PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            DEFAULT_PRINT_PROPERTIES | PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(MeasurementType::Instantaneous)
             .set(VIFRange::ErrorFlags),

--- a/components/wmbus_common/driver_ultraheat.cc
+++ b/components/wmbus_common/driver_ultraheat.cc
@@ -106,7 +106,7 @@ namespace
         addStringFieldWithExtractorAndLookup(
             "status",
             "Meter status.",
-            PrintProperty::STATUS | PrintProperty::INCLUDE_TPL_STATUS,
+            PrintProperty::STATUS_FIELD | PrintProperty::INCLUDE_TPL_STATUS,
             FieldMatcher::build()
             .set(VIFRange::ErrorFlags),
             Translate::Lookup(

--- a/components/wmbus_common/driver_unismart.cc
+++ b/components/wmbus_common/driver_unismart.cc
@@ -40,7 +40,7 @@ Driver::Driver(MeterInfo &mi, DriverInfo &di)
 
   addStringFieldWithExtractorAndLookup(
       "status", "Status of meter?",
-      DEFAULT_PRINT_PROPERTIES | PrintProperty::STATUS,
+      DEFAULT_PRINT_PROPERTIES | PrintProperty::STATUS_FIELD,
       FieldMatcher::build().set(DifVifKey("02FD74")),
       {
           {
@@ -55,7 +55,7 @@ Driver::Driver(MeterInfo &mi, DriverInfo &di)
 
   addStringFieldWithExtractorAndLookup(
       "other", "Other status of meter?",
-      DEFAULT_PRINT_PROPERTIES | PrintProperty::STATUS,
+      DEFAULT_PRINT_PROPERTIES | PrintProperty::STATUS_FIELD,
       FieldMatcher::build().set(DifVifKey("017F")),
       {
           {

--- a/components/wmbus_common/driver_waterstarm.cc
+++ b/components/wmbus_common/driver_waterstarm.cc
@@ -45,7 +45,7 @@ namespace
         addStringFieldWithExtractorAndLookup(
             "status",
             "Status and error flags.",
-            DEFAULT_PRINT_PROPERTIES | PrintProperty::INCLUDE_TPL_STATUS | PrintProperty::STATUS,
+            DEFAULT_PRINT_PROPERTIES | PrintProperty::INCLUDE_TPL_STATUS | PrintProperty::STATUS_FIELD,
             FieldMatcher::build()
             .set(VIFRange::ErrorFlags),
             {
@@ -96,7 +96,7 @@ namespace
         addStringFieldWithExtractorAndLookup(
             "current_status",
             "Status and error flags. (Deprecated use status instead.)",
-            DEFAULT_PRINT_PROPERTIES | PrintProperty::INCLUDE_TPL_STATUS | PrintProperty::STATUS | PrintProperty::DEPRECATED,
+            DEFAULT_PRINT_PROPERTIES | PrintProperty::INCLUDE_TPL_STATUS | PrintProperty::STATUS_FIELD | PrintProperty::DEPRECATED,
             FieldMatcher::build()
             .set(VIFRange::ErrorFlags),
             {

--- a/components/wmbus_common/driver_watertech.cc
+++ b/components/wmbus_common/driver_watertech.cc
@@ -41,7 +41,7 @@ namespace
         addStringFieldWithExtractorAndLookup(
             "status",
             "Status and error flags.",
-            DEFAULT_PRINT_PROPERTIES | PrintProperty::INCLUDE_TPL_STATUS | PrintProperty::STATUS,
+            DEFAULT_PRINT_PROPERTIES | PrintProperty::INCLUDE_TPL_STATUS | PrintProperty::STATUS_FIELD,
             FieldMatcher::build()
             .set(VIFRange::ErrorFlags),
             {

--- a/components/wmbus_common/meters.cc
+++ b/components/wmbus_common/meters.cc
@@ -2315,7 +2315,7 @@ const char *toString(PrintProperty p) {
     return "REQUIRED";
   case PrintProperty::DEPRECATED:
     return "DEPRECATED";
-  case PrintProperty::STATUS:
+  case PrintProperty::STATUS_FIELD:
     return "STATUS";
   case PrintProperty::INCLUDE_TPL_STATUS:
     return "INCLUDE_TPL_STATUS";
@@ -2336,7 +2336,7 @@ PrintProperty toPrintProperty(const char *s) {
   if (!strcmp(s, "DEPRECATED"))
     return PrintProperty::DEPRECATED;
   if (!strcmp(s, "STATUS"))
-    return PrintProperty::STATUS;
+    return PrintProperty::STATUS_FIELD;
   if (!strcmp(s, "INCLUDE_TPL_STATUS"))
     return PrintProperty::INCLUDE_TPL_STATUS;
   if (!strcmp(s, "INJECT_INTO_STATUS"))

--- a/components/wmbus_common/meters.h
+++ b/components/wmbus_common/meters.h
@@ -262,7 +262,7 @@ enum PrintProperty {
                 // or null.
   DEPRECATED = 2, // This field is about to be removed or changed in a newer
                   // driver, which will have a new name.
-  STATUS = 4, // This is >the< status field and it should read OK of not error
+  STATUS_FIELD = 4, // This is >the< status field and it should read OK of not error
               // flags are set.
   INCLUDE_TPL_STATUS = 8,  // This text field also includes the tpl status
                            // decoding. multiple OK:s collapse to a single OK.
@@ -281,7 +281,7 @@ struct PrintProperties {
 
   bool hasREQUIRED() { return props_ & PrintProperty::REQUIRED; }
   bool hasDEPRECATED() { return props_ & PrintProperty::DEPRECATED; }
-  bool hasSTATUS() { return props_ & PrintProperty::STATUS; }
+  bool hasSTATUS() { return props_ & PrintProperty::STATUS_FIELD; }
   bool hasINCLUDETPLSTATUS() {
     return props_ & PrintProperty::INCLUDE_TPL_STATUS;
   }


### PR DESCRIPTION
Fixes #404.

ESPHome 2026.7.0 changed the default ESP32 build to the native ESP-IDF toolchain. Its ESP-IDF 5.5.4 headers declare a deprecated global typedef in `rom/ets_sys.h`:

```c
} STATUS __attribute__((deprecated("Use ETS_STATUS instead")));
```

`wmbus_common/meters.h` declares `PrintProperty` as an unscoped enum, so its `STATUS` enumerator leaks into the global namespace and collides with that typedef whenever both headers are visible in the same translation unit. With ESPHome ≥ 2026.7.0 that always happens: the core `sha256` component pulls in `mbedtls/sha256.h` → `sha256_alt.h` → `rom/sha.h` → `rom/ets_sys.h`, so every build fails with:

```
components/wmbus_common/meters.h:265:12: error: 'STATUS' redeclared as different kind of entity
```

This renames the enumerator to `STATUS_FIELD` (it marks ">the< status field", per its own comment). All uses were already qualified as `PrintProperty::STATUS`, so the change is a mechanical rename across 52 files with no behavioral impact; the `PrintProperties::hasSTATUS()` accessor keeps its name.

Note that after this fix, native-toolchain builds still stop at the link stage with the undefined references reported in #403 — that failure is a separate ESPHome core issue (its generated ESP-IDF CMakeLists only globs `*.cpp`/`*.c`, silently skipping this component's vendored `*.cc` sources) for which I am submitting a companion fix to esphome.

Verified by building an ESP32-C6 (SX1262) IZAR configuration with ESPHome 2026.7.0: compilation fails in `meters.h` before this change and proceeds past it with it; with the companion esphome `.cc` glob fix also applied, the native ESP-IDF toolchain build succeeds end to end, and the `toolchain: platformio` workaround from #401 is no longer needed. The PlatformIO toolchain build is unaffected.
