### PR TITLE
Fixes for CC1101

### DIFF
--- a/ESP32-NodeMcu-32s_CC1101.yaml
+++ b/ESP32-NodeMcu-32s_CC1101.yaml
@@ -1,0 +1,217 @@
+substitutions:
+  name: "wmbus-reader"
+  friendlyname: "wmbus reader"
+  id: "wmbus-reader"
+
+esphome:
+  name: ${name}
+  friendly_name: ${friendlyname}
+  name_add_mac_suffix: false
+
+esp32:
+  board: nodemcu-32s
+  framework:
+    type: esp-idf
+
+external_components:
+  - source: github://SzczepanLeon/esphome-components@main
+    components: [wmbus_radio, wmbus_common, wmbus_meter]
+    refresh: 0s
+
+mdns:
+  disabled: false
+
+time:
+  - platform: homeassistant
+
+logger:
+  level: DEBUG
+  logs:
+    packet: INFO      # Mute "Have data from radio (... bytes)"
+    wmbusmeters: INFO # Mute "raw packet", "trimming frame", "checkWMBUSFrame"
+    main: INFO        # Mute raw "Frame received"
+    CC1101: ERROR     # Mute warnings "RX timeout after 0 bytes"
+
+
+api:
+  encryption:
+    key: !secret api_key
+ota:
+  - platform: esphome
+    password: !secret ota_password
+
+#web_server:
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  output_power: 8.5dB
+  reboot_timeout: 5min
+  ap:
+    ssid: $id
+    password: !secret failover_password
+
+  power_save_mode: none
+
+captive_portal:
+
+web_server:
+  port: 80
+  version: 3
+
+# SPI Configuration for CC1101
+spi:
+  mosi_pin: GPIO32
+  clk_pin: GPIO33
+  miso_pin: GPIO19
+
+# CC1101 Radio Configuration
+# Note: CC1101 has no hardware reset pin - do not configure reset_pin
+wmbus_radio:
+  radio_type: CC1101
+  irq_pin: GPIO22
+  cs_pin: GPIO23
+
+  frequency: 868.950MHz
+  sync_mode: NORMAL
+
+  on_frame:
+    - then:
+        - logger.log:
+            format: "Frame received: RSSI=%ddBm, Mode=%s, Data=%s"
+            args: [ 'frame->rssi()', 'toString(frame->link_mode())', 'frame->as_hex().c_str()' ]
+
+# Uncomment and list only the drivers you need to save flash space
+wmbus_common:
+  drivers:
+    - apator162
+
+
+# Define your water meter
+wmbus_meter:
+  - id: water_meter
+    meter_id:  0x12345678
+    type: apator162
+    key: "00000000000000000000000000000000"
+    # mode:
+    #   - C1
+    on_telegram:
+      - logger.log:
+          format: "Telegram received from water meter"
+
+sensor:
+  - platform: wifi_signal
+    name: ${friendlyname} WiFi Signal
+    id: wifi_signal_db
+    update_interval: 120s
+    entity_category: diagnostic
+    unit_of_measurement: "dBm"
+    device_class: signal_strength
+    state_class: measurement
+    accuracy_decimals: 0
+
+  - platform: copy # Reports the WiFi signal strength in %
+    source_id: wifi_signal_db
+    name: "WiFi Signal Percent"
+    filters:
+      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
+    unit_of_measurement: "%"
+    entity_category: "diagnostic"
+
+
+
+  - platform: uptime
+    name: ${friendlyname} Uptime
+    filters:
+      - lambda: return x / 3600;
+    unit_of_measurement: "h"
+    entity_category: diagnostic
+
+  # RSSI
+  - platform: wmbus_meter
+    parent_id: water_meter
+    field: rssi_dbm
+    name: "RSSI APATOR"
+    unit_of_measurement: "dBm"
+    device_class: signal_strength
+    state_class: measurement
+    entity_category: diagnostic
+    accuracy_decimals: 0
+    icon: "mdi:signal"
+
+  # Water meter total consumption
+  - platform: wmbus_meter
+    parent_id: water_meter
+    field: total_m3
+    name: "Zimna woda"
+    unit_of_measurement: "m³"
+    device_class: water
+    state_class: total_increasing
+    accuracy_decimals: 3
+    icon: "mdi:water"
+
+  # Target/Last month reading
+  - platform: wmbus_meter
+    parent_id: water_meter
+    field: target_m3
+    name: "Water Target"
+    unit_of_measurement: "m³"
+    accuracy_decimals: 3
+    icon: "mdi:counter"
+
+  # Flow temperature
+  - platform: wmbus_meter
+    parent_id: water_meter
+    field: flow_temperature_c
+    name: "Water Temperature"
+    unit_of_measurement: "°C"
+    device_class: temperature
+    accuracy_decimals: 1
+
+  # External/Ambient temperature
+  - platform: wmbus_meter
+    parent_id: water_meter
+    field: external_temperature_c
+    name: "Meter Ambient Temperature"
+    unit_of_measurement: "°C"
+    device_class: temperature
+    accuracy_decimals: 1
+
+
+text_sensor:
+  - platform: version
+    name: ${friendlyname} Version
+    entity_category: diagnostic
+
+  - platform: wifi_info
+    ip_address:
+      name: ip
+    ssid:
+      name: ssid
+    bssid:
+      name: bssid
+
+  - platform: wmbus_meter
+    parent_id: water_meter
+    field: current_alarms
+    name: "Water Meter Alarms"
+
+  - platform: wmbus_meter
+    parent_id: water_meter
+    field: status
+    name: "Water Meter Status"
+
+binary_sensor:
+  - platform: status
+    name: ${friendlyname} Status
+    entity_category: diagnostic
+
+button:
+  - platform: safe_mode
+    name: "${friendlyname} Restart (Safe Mode)"
+    entity_category: diagnostic
+
+
+  - platform: restart
+    name: "${friendlyname} Restart"
+    entity_category: diagnostic

--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 Version 5 based on Kuba's dirty [fork](https://github.com/IoTLabs-pl/esphome-components).
 
-> **_NOTE:_**  Component with CC1101 support is here:
-[version 4](https://github.com/SzczepanLeon/esphome-components/tree/version_4)
-[version 3](https://github.com/SzczepanLeon/esphome-components/tree/version_3)
-[version 2](https://github.com/SzczepanLeon/esphome-components/tree/version_2)
-
-
 # TODO:
 - Prepare packages for ready made boards (like UltimateReader) with displays, leds etc.
 - Aggresive cleanup of wmbusmeters classes/structs
@@ -216,6 +210,25 @@ wmbus_radio:
 | `frequency` | no | `868.95MHz` | Operating frequency, 300–928 MHz |
 
 Tested on ESP32-C3 Super Mini + CC1101 v2.0 (E07-M1101D-SMA) blue board.
+
+
+Another tested device: NodeMCU-32S (ESP-32S) Development Board, ESP-WROOM-32, ESP32 Dev Board + CC1101:
+
+```yaml
+spi:
+  clk_pin: GPIO33
+  mosi_pin: GPIO32
+  miso_pin: GPIO19
+
+wmbus_radio:
+  radio_type: CC1101
+  cs_pin: GPIO23
+  irq_pin: GPIO22
+  frequency: 868.95MHz   # Optional. Range: 300–928 MHz. Default: 868.95 MHz
+```
+
+For full example see: [ESP32-NodeMcu-32s_CC1101.yaml](ESP32-NodeMcu-32s_CC1101.yaml)
+
 
 ### SX1276
 For SX1276 radio you need to configure SPI instance as usual in ESPHome and additionally specify reset pin and IRQ pin (as DIO1). Interrupts are triggered on non empty FIFO.

--- a/components/wmbus_common/driver_apator162.cpp
+++ b/components/wmbus_common/driver_apator162.cpp
@@ -42,7 +42,7 @@ namespace
         di.setConstructor([](MeterInfo& mi, DriverInfo& di){ return std::shared_ptr<Meter>(new Driver(mi, di)); });
     });
 
-    Driver::Driver(MeterInfo &mi, DriverInfo &di) : MeterCommonImplementation(mi, di)
+    [[maybe_unused]] Driver::Driver(MeterInfo &mi, DriverInfo &di) : MeterCommonImplementation(mi, di)
     {
         processExtras(mi.extras);
 

--- a/components/wmbus_common/formula.cpp
+++ b/components/wmbus_common/formula.cpp
@@ -865,7 +865,7 @@ bool FormulaImplementation::go() {
 }
 
 Token *FormulaImplementation::LA(size_t i) {
-  if (i < 0 || i >= tokens_.size())
+  if (i >= tokens_.size())
     return NULL;
   return &tokens_[i];
 }

--- a/components/wmbus_common/meters.cpp
+++ b/components/wmbus_common/meters.cpp
@@ -474,7 +474,7 @@ std::string MeterCommonImplementation::datetimeOfUpdateRobot() {
 std::string MeterCommonImplementation::unixTimestampOfUpdate() {
   char ut[40];
   memset(ut, 0, sizeof(ut));
-  snprintf(ut, sizeof(ut) - 1, "%lu", datetime_of_update_);
+  snprintf(ut, sizeof(ut) - 1, "%llu", (unsigned long long)datetime_of_update_);
   return std::string(ut);
 }
 

--- a/components/wmbus_common/util.cpp
+++ b/components/wmbus_common/util.cpp
@@ -371,13 +371,13 @@ void logTelegram(std::vector<uchar> &original, std::vector<uchar> &parsed,
   std::string header = parsed_hex.substr(0, header_size * 2);
   std::string content = parsed_hex.substr(header_size * 2);
   if (suffix_size == 0) {
-    notice("telegram=|%s_%s|+%ld\n", header.c_str(), content.c_str(), diff);
+    notice("telegram=|%s_%s|+%lld\n", header.c_str(), content.c_str(), (long long)diff);
   } else {
     assert((suffix_size * 2) < (int)content.size());
     std::string content2 = content.substr(0, content.size() - suffix_size * 2);
     std::string suffix = content.substr(content.size() - suffix_size * 2);
-    notice("telegram=|%s_%s_%s|+%ld\n", header.c_str(), content2.c_str(),
-           suffix.c_str(), diff);
+    notice("telegram=|%s_%s_%s|+%lld\n", header.c_str(), content2.c_str(),
+           suffix.c_str(), (long long)diff);
   }
 }
 
@@ -407,7 +407,7 @@ std::string eatTo(std::vector<uchar> &v, std::vector<uchar>::iterator &i, int c,
 void padWithZeroesTo(std::vector<uchar> *content, size_t len,
                      std::vector<uchar> *full_content) {
   if (content->size() < len) {
-    warning("Padded with zeroes.", (int)len);
+    warning("Padded with zeroes to %d bytes.", (int)len);
     size_t old_size = content->size();
     content->resize(len);
     for (size_t i = old_size; i < len; ++i) {

--- a/components/wmbus_common/wmbus.h
+++ b/components/wmbus_common/wmbus.h
@@ -320,10 +320,11 @@ struct Meter;
 
 struct Telegram {
 private:
-  Telegram(Telegram &t) {}
+  Telegram(const Telegram &t) = default;
 
 public:
   Telegram() = default;
+  Telegram& operator=(const Telegram &t) = default;
 
   AboutTelegram about;
 

--- a/components/wmbus_radio/component.cpp
+++ b/components/wmbus_radio/component.cpp
@@ -7,7 +7,7 @@
   {                                                                            \
     auto result = (expr);                                                      \
     if (!!result != expected) {                                                \
-      ESP_LOGE(TAG, "Assertion failed: %s -> %d", #expr, result);              \
+      ESP_LOGE(TAG, "Assertion failed: %s -> %d", #expr, (int)(uintptr_t)result);              \
       before_exit;                                                             \
       return;                                                                  \
     }                                                                          \

--- a/components/wmbus_radio/packet.cpp
+++ b/components/wmbus_radio/packet.cpp
@@ -20,12 +20,15 @@ Packet::Packet() { this->data_.reserve(WMBUS_PREAMBLE_SIZE); }
 
 // Determine the link mode based on the first byte of the data
 LinkMode Packet::link_mode() {
-  if (this->link_mode_ == LinkMode::UNKNOWN)
-    if (this->data_.size())
-      if (this->data_[0] == WMBUS_MODE_C_PREAMBLE)
+  if (this->link_mode_ == LinkMode::UNKNOWN) {
+    if (this->data_.size()) {
+      if (this->data_[0] == WMBUS_MODE_C_PREAMBLE) {
         this->link_mode_ = LinkMode::C1;
-      else
+      } else {
         this->link_mode_ = LinkMode::T1;
+      }
+    }
+  }
 
   return this->link_mode_;
 }

--- a/components/wmbus_radio/packet.cpp
+++ b/components/wmbus_radio/packet.cpp
@@ -36,12 +36,17 @@ void Packet::set_rssi(int8_t rssi) { this->rssi_ = rssi; }
 uint8_t Packet::l_field() {
   switch (this->link_mode()) {
   case LinkMode::C1:
-    return this->data_[2];
+    if (this->data_.size() > 2)
+      return this->data_[2];
+    break;
   case LinkMode::T1: {
     auto decoded = decode3of6(this->data_);
-    if (decoded)
+    if (decoded && !decoded->empty())
       return (*decoded)[0];
+    break;
   }
+  default:
+    break;
   }
   return 0;
 }
@@ -63,12 +68,13 @@ size_t Packet::expected_size() {
     // block
     auto nrBytes = l_field + 1 + 2 * nrBlocks;
 
-    if (this->link_mode() != LinkMode::C1)
+    if (this->link_mode() != LinkMode::C1) {
       this->expected_size_ = encoded_size(nrBytes);
-    else if (this->data_[1] == WMBUS_BLOCK_A_PREAMBLE)
+    } else if (this->data_.size() > 1 && this->data_[1] == WMBUS_BLOCK_A_PREAMBLE) {
       this->expected_size_ = WMBUS_MODE_C_SUFIX_LEN + nrBytes;
-    else if (this->data_[1] == WMBUS_BLOCK_B_PREAMBLE)
+    } else if (this->data_.size() > 1 && this->data_[1] == WMBUS_BLOCK_B_PREAMBLE) {
       this->expected_size_ = WMBUS_MODE_C_SUFIX_LEN + 1 + l_field;
+    }
   }
   ESP_LOGV(TAG, "expected_size: %zu", this->expected_size_);
   return this->expected_size_;
@@ -105,12 +111,16 @@ std::optional<Frame> Packet::convert_to_frame() {
       if (decoded_data)
         this->data_ = decoded_data.value();
     } else if (this->link_mode() == LinkMode::C1) {
-      if (this->data_[1] == WMBUS_BLOCK_A_PREAMBLE)
-        this->frame_format_ = "A";
-      else if (this->data_[1] == WMBUS_BLOCK_B_PREAMBLE)
-        this->frame_format_ = "B";
-      this->data_.erase(this->data_.begin(),
-                        this->data_.begin() + WMBUS_MODE_C_SUFIX_LEN);
+      if (this->data_.size() > 1) {
+        if (this->data_[1] == WMBUS_BLOCK_A_PREAMBLE)
+          this->frame_format_ = "A";
+        else if (this->data_[1] == WMBUS_BLOCK_B_PREAMBLE)
+          this->frame_format_ = "B";
+      }
+      if (this->data_.size() >= WMBUS_MODE_C_SUFIX_LEN) {
+        this->data_.erase(this->data_.begin(),
+                          this->data_.begin() + WMBUS_MODE_C_SUFIX_LEN);
+      }
     } else {
       ESP_LOGE(TAG, "unknown link mode!");
     }
@@ -122,14 +132,14 @@ std::optional<Frame> Packet::convert_to_frame() {
   bool crcOk = false;
 
   if (this->frame_format_ == "A") {
-      crcOk = trimCRCsFrameFormatA(this->data_);
-  } else {
-      crcOk = trimCRCsFrameFormatB(this->data_);
+    crcOk = trimCRCsFrameFormatA(this->data_);
+  } else if (this->frame_format_ == "B") {
+    crcOk = trimCRCsFrameFormatB(this->data_);
   }
 
   int dummy;
   if (crcOk && (checkWMBusFrame(this->data_, (size_t *)&dummy, &dummy, &dummy, false) ==
-      FrameStatus::FullFrame))
+                FrameStatus::FullFrame))
     frame.emplace(this);
 
   delete this;
@@ -150,9 +160,12 @@ std::vector<uint8_t> Frame::as_raw() { return this->data_; }
 std::string Frame::as_hex() { return format_hex(this->data_); }
 std::string Frame::as_rtlwmbus() {
   const size_t time_repr_size = sizeof("YYYY-MM-DD HH:MM:SS.00Z");
-  char time_buffer[time_repr_size];
+  char time_buffer[time_repr_size] = "1970-01-01 00:00:00.00Z";
   auto t = std::time(NULL);
-  std::strftime(time_buffer, time_repr_size, "%F %T.00Z", std::gmtime(&t));
+  auto *tm_info = std::gmtime(&t);
+  if (tm_info != nullptr) {
+    std::strftime(time_buffer, time_repr_size, "%F %T.00Z", tm_info);
+  }
 
   auto output = std::string{};
   output.reserve(2 + 5 + 24 + 1 + 4 + 5 + 2 * this->data_.size() + 1);

--- a/components/wmbus_radio/transceiver.cpp
+++ b/components/wmbus_radio/transceiver.cpp
@@ -70,7 +70,7 @@ bool RadioTransceiver::wait_busy(uint32_t timeout_ms) {
   uint32_t start = millis();
   while (this->busy_pin_->digital_read()) {
     if (millis() - start > timeout_ms) {
-      ESP_LOGE(TAG, "BUSY pin timeout after %u ms", timeout_ms);
+      ESP_LOGE(TAG, "BUSY pin timeout after %lu ms", timeout_ms);
       this->mark_failed();
       return false;
     }

--- a/components/wmbus_radio/transceiver_cc1101.cpp
+++ b/components/wmbus_radio/transceiver_cc1101.cpp
@@ -255,7 +255,7 @@ int8_t CC1101::get_rssi() {
   // Convert RSSI_dec to dBm: RSSI_dBm = (RSSI_dec / 2) - RSSI_offset
   // RSSI offset per TI DN505: 74 dBm for 868 MHz, 76 dBm for 433 MHz
   int8_t rssi_offset = (this->frequency_hz_ < 600000000u) ? 76 : 74;
-  int8_t rssi_dec = this->last_rssi_;
+  uint8_t rssi_dec = this->last_rssi_;
   int16_t rssi_dbm;
   if (rssi_dec >= 128) {
     rssi_dbm = ((int16_t)(rssi_dec - 256) / 2) - rssi_offset;
@@ -315,7 +315,7 @@ bool CC1101::read_in_task(uint8_t *buffer, size_t length, uint32_t offset) {
 
     // Timeout: 500ms without progress
     if (millis() - last_progress > 500) {
-      ESP_LOGW(TAG, "RX timeout after %zu bytes (need %zu)", total + offset, length + offset);
+      ESP_LOGW(TAG, "RX timeout after %lu bytes (need %lu)", (unsigned long)(total + offset), (unsigned long)(length + offset));
       return false;
     }
 


### PR DESCRIPTION
### Summary
* **CC1101:** Fixed crashes caused by corrupt packets and signal noise on ESP32-S.
* **Compatibility:** Fixed build warnings reported in ESPHome `2026.7`.
* **Docs:** Added an additional configuration example for CC1101 and cleaned up outdated version links in `README.md`.

### Testing
Verified on **NodeMCU-32S + CC1101** with **ESPHome 2026.7.2**, reading an **Apator 162** water meter.