### PR TITLE
Hex vs Decimal - Telegram not handled by any handler - https://github…

### DIFF
--- a/components/wmbus_meter/__init__.py
+++ b/components/wmbus_meter/__init__.py
@@ -76,7 +76,7 @@ async def to_code(config):
     meter = cg.new_Pvariable(config[CONF_ID])
     cg.add(
         meter.set_meter_params(
-            str('{:08x}'.format(config[CONF_METER_ID])),
+            str('{:08d}'.format(config[CONF_METER_ID])),
             config[CONF_TYPE],
             config.get(CONF_KEY, ""),
             config[CONF_MODE],


### PR DESCRIPTION
Prevent not being able to match meter-id received with configured id by treating the meter-id as decimal instead of hex instead of outputting `Telegram not handled by any handler`
More details in https://github.com/SzczepanLeon/esphome-components/issues/423