### PR TITLE
remove unused rtc dependency

### DIFF
--- a/ESP32-C3_SuperMini_CC1101.yaml
+++ b/ESP32-C3_SuperMini_CC1101.yaml
@@ -34,9 +34,6 @@ logger:
   hardware_uart: USB_CDC
   level: DEBUG
 
-time:
-  - platform: homeassistant
-
 api:
   encryption:
     key: !secret api_encryption_key

--- a/ESP32-NodeMcu-32s_CC1101.yaml
+++ b/ESP32-NodeMcu-32s_CC1101.yaml
@@ -21,9 +21,6 @@ external_components:
 mdns:
   disabled: false
 
-time:
-  - platform: homeassistant
-
 logger:
   level: DEBUG
   logs:

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ api:
 web_server:
   version: 3 
 
+# Optional - only needed for the timestamp / timestamp_zulu fields below
 time:
   - platform: homeassistant
 

--- a/UltimateReader_v5.yaml
+++ b/UltimateReader_v5.yaml
@@ -44,9 +44,6 @@ wifi:
 
 captive_portal:
 
-time:
-  - platform: homeassistant
-
 api:
 
 ota:

--- a/components/wmbus_meter/wmbus_meter.h
+++ b/components/wmbus_meter/wmbus_meter.h
@@ -2,8 +2,6 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 
-#include "esphome/components/time/real_time_clock.h"
-
 #include "esphome/components/wmbus_common/meters.h"
 #include "esphome/components/wmbus_radio/component.h"
 
@@ -29,7 +27,6 @@ public:
 
 protected:
   LinkModeSet link_modes_;
-  time::RealTimeClock *rtc;
   wmbus_radio::Radio *radio;
 
   // Retained so the component can identify itself when meter is null.


### PR DESCRIPTION
wmbus_meter.h included esphome/components/time/real_time_clock.h and declared a protected member `time::RealTimeClock *rtc;`. That member is never assigned or read anywhere in the repository - there is no set_rtc(), no time_id config option, and no reference to it in any .cpp file.

Meter timestamps come from the wmbusmeters library, which uses the POSIX clock (localtime() in wmbus_common/meters.cpp), not the ESPHome RTC object. Because __init__.py declares neither DEPENDENCIES nor AUTO_LOAD for time, ESPHome does not copy the time component sources unless the user happens to have a time: block in their YAML, so any config without one fails to build with: fatal error: esphome/components/time/real_time_clock.h: No such file or directory. 

Removing the include and the dead member drops the hidden dependency with no functional change.