### PR TITLE
Add native support for Kamstrup FlowIQ 2200 compact frame (0xdd07)

### DIFF
--- a/components/wmbus_common/driver_flowiq2200.cpp
+++ b/components/wmbus_common/driver_flowiq2200.cpp
@@ -66,6 +66,29 @@ namespace
                 },
             });
 
+        addStringFieldWithExtractorAndLookup(
+            "status",
+            "Status of meter.",
+            DEFAULT_PRINT_PROPERTIES | PrintProperty::STATUS_FIELD,
+            FieldMatcher::build()
+            .set(DifVifKey("02FF20")),
+            {
+                {
+                    {
+                        "ERROR_FLAGS",
+                        Translate::MapType::BitToString,
+                        AlwaysTrigger, MaskBits(0x000f),
+                        "OK",
+                        {
+                            { 0x01 , "DRY" },
+                            { 0x02 , "REVERSE" },
+                            { 0x04 , "LEAK" },
+                            { 0x08 , "BURST" },
+                        }
+                    },
+                },
+            });
+
         addNumericFieldWithExtractor(
             "total",
             "The total water consumption recorded by this meter.",
@@ -329,6 +352,12 @@ namespace
 // telegram=|3244372C763081233C168D2057D2ED11205a817905095480_0008000000000000000008900008F0FFC12B0A1B23001F0F000013|
 // {"_":"telegram","media":"cold water","meter":"flowiq2200","name":"Votten","id":"23813076","status":"ERROR_FLAGS_800","total_m3":3.871,"target_m3":0,"target_date":"2022-11-01","flow_m3h":0.035,"max_external_temperature_c":27,"min_external_temperature_c":10,"max_flow_m3h":0,"timestamp":"1111-11-11T11:11:11Z"}
 // |Votten;23813076;ERROR_FLAGS_800;3.871;0;1111-11-11 11:11.11
+
+
+// Test: FlowIQ2200_dd07 flowiq2200 12345678 NOKEY
+// telegram=|1A44372C785634123A167907DD645C8A6334CF02002BA702004138|
+// {"_":"telegram","media":"cold water","meter":"flowiq2200","name":"FlowIQ2200_dd07","id":"12345678","status":"BURST REVERSE","total_m3":184.116,"target_m3":173.867,"target_date":"2026-08-01","time_bursting":"2-3 days","time_dry":"","time_leaking":"","time_reversed":"22-31 days","timestamp":"1111-11-11T11:11:11Z"}
+// |FlowIQ2200_dd07;12345678;BURST REVERSE;184.116;173.867;1111-11-11 11:11.11
 
 
 KEEP_DRIVER(flowiq2200);

--- a/components/wmbus_common/wmbus.cpp
+++ b/components/wmbus_common/wmbus.cpp
@@ -4679,6 +4679,10 @@ bool Telegram::findFormatBytesFromKnownMeterSignatures(
     hex2bin("04FF2304134413426C023B92013BA2013B06FF1BA1015B91015BA10167",
             format_bytes);
     debug("(wmbus) using hard coded format for hash f3a9\n");
+  } else if (format_signature == 0x07dd || format_signature == 0xdd07) {
+    // Kamstrup FlowIQ2200 compact frame variant seen with signature dd07.
+    hex2bin("02FF2004134413426C", format_bytes);
+    debug("(wmbus) using hard coded format for hash dd07\n");
   } else {
     ok = false;
   }


### PR DESCRIPTION
### Description

This PR adds native support for the compact frame variant transmitted by **Kamstrup FlowIQ 2200** water meters with signature hash **`0xdd07`** (CI=`0x79`, Short TPL).

Prior to this change, the meter parser discarded compact frames until a descriptive full frame arrived. Adding this known format signature allows ESPHome to decode telegrams immediately on boot without waiting for full frames.

### Details & Format Mapping
- **Signature Hash:** `0xdd07` / `0x07dd`
- **Descriptor sequence:** `"02FF2004134413426C"`
  - `0x02, 0xFF, 0x20`: 16-bit Status / Manufacturer-specific diagnostic register (`status`, `time_dry`, `time_reversed`, `time_leaking`, `time_bursting`)
  - `0x04, 0x13`: 32-bit Integer Instantaneous Volume (10^-3 m³) -> `total_m3`
  - `0x44, 0x13`: 32-bit Integer Storage 1 Target Volume (10^-3 m³) -> `target_m3`
  - `0x42, 0x6C`: 16-bit Date Type G Storage 1 Reference Date -> `target_date`

### Changes
- Registered `"02FF2004134413426C"` for hash `0xdd07` / `0x07dd` in `Telegram::findFormatBytesFromKnownMeterSignatures` (`wmbus.cpp`).
- Added `02FF20` status extractor lookup to `driver_flowiq2200.cpp`.
- Added test telegram comment in `driver_flowiq2200.cpp`.